### PR TITLE
feat: Add calendar-aware semantic retrieval and temporal gating

### DIFF
--- a/tana_context_mask/api/mcp_server.py
+++ b/tana_context_mask/api/mcp_server.py
@@ -27,26 +27,57 @@ class MCPServer:
             {
                 "name": "acquire_context",
                 "description": "Proactively retrieve background context, hierarchy, and references from Tana knowledge graph for a given AI task or conversation topic.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "task": {"type": "string", "description": "The current task, question, or user objective."},
+                        "query": {"type": "string", "description": "Optional specific search query keywords."},
+                        "scope": {"type": "string", "description": "Optional supertag filter (e.g. 'Project', 'Task')."},
+                        "max_nodes": {"type": "integer", "description": "Maximum context nodes to return (default 8)."},
+                        "target_date": {"type": "string", "description": "Optional target date (YYYY-MM-DD) for historical context."},
+                        "temporal_mode": {"type": "string", "enum": ["none", "boost", "filter", "strict"], "description": "Temporal gating mode."}
+                    },
+                    "required": ["task"]
+                },
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "task": {"type": "string", "description": "The current task, question, or user objective."},
                         "query": {"type": "string", "description": "Optional specific search query keywords."},
                         "scope": {"type": "string", "description": "Optional supertag filter (e.g. 'Project', 'Task')."},
-                        "max_nodes": {"type": "integer", "description": "Maximum context nodes to return (default 8)."}
+                        "max_nodes": {"type": "integer", "description": "Maximum context nodes to return (default 8)."},
+                        "target_date": {"type": "string", "description": "Optional target date (YYYY-MM-DD) for historical context."},
+                        "temporal_mode": {"type": "string", "enum": ["none", "boost", "filter", "strict"], "description": "Temporal gating mode."}
                     },
                     "required": ["task"]
                 }
             },
             {
                 "name": "search_nodes",
-                "description": "Perform hybrid semantic and keyword search across the entire Tana workspace.",
+                "description": "Perform hybrid semantic and keyword search across the entire Tana workspace with calendar provenance and temporal gating.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "The search term or conceptual phrase."},
+                        "limit": {"type": "integer", "description": "Number of results to return (default 10)."},
+                        "tag_filter": {"type": "string", "description": "Optional tag name to filter by."},
+                        "target_date": {"type": "string", "description": "Optional target date (YYYY-MM-DD) for temporal proximity or historical query anchoring."},
+                        "date_from": {"type": "string", "description": "Optional start date (YYYY-MM-DD) filter."},
+                        "date_to": {"type": "string", "description": "Optional end date (YYYY-MM-DD) filter."},
+                        "temporal_mode": {"type": "string", "enum": ["none", "boost", "filter", "strict"], "description": "Temporal gating mode: 'none', 'boost' (decay reranking), 'filter' (range pruning), 'strict' (calendar verified occurrence only)."}
+                    },
+                    "required": ["query"]
+                },
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "query": {"type": "string", "description": "The search term or conceptual phrase."},
                         "limit": {"type": "integer", "description": "Number of results to return (default 10)."},
-                        "tag_filter": {"type": "string", "description": "Optional tag name to filter by."}
+                        "tag_filter": {"type": "string", "description": "Optional tag name to filter by."},
+                        "target_date": {"type": "string", "description": "Optional target date (YYYY-MM-DD) for temporal proximity or historical query anchoring."},
+                        "date_from": {"type": "string", "description": "Optional start date (YYYY-MM-DD) filter."},
+                        "date_to": {"type": "string", "description": "Optional end date (YYYY-MM-DD) filter."},
+                        "temporal_mode": {"type": "string", "enum": ["none", "boost", "filter", "strict"], "description": "Temporal gating mode: 'none', 'boost' (decay reranking), 'filter' (range pruning), 'strict' (calendar verified occurrence only)."}
                     },
                     "required": ["query"]
                 }
@@ -54,6 +85,13 @@ class MCPServer:
             {
                 "name": "get_node_details",
                 "description": "Inspect a single Tana node with its parent breadcrumbs, immediate children, tags, and field values.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "node_id": {"type": "string", "description": "The Tana node ID."}
+                    },
+                    "required": ["node_id"]
+                },
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -65,6 +103,14 @@ class MCPServer:
             {
                 "name": "expand_graph",
                 "description": "Expand 1-2 hops of graph edges (parents, sub-items, references, backlinks) around a Tana node.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "node_id": {"type": "string", "description": "The seed node ID to expand from."},
+                        "hops": {"type": "integer", "description": "Graph depth (1 or 2)."}
+                    },
+                    "required": ["node_id"]
+                },
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -77,6 +123,13 @@ class MCPServer:
             {
                 "name": "sync_mirror",
                 "description": "Trigger synchronization with Tana Remote MCP or bootstrap from a local export.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "mode": {"type": "string", "enum": ["incremental", "bootstrap"], "description": "Sync mode."},
+                        "lookback_days": {"type": "integer", "description": "Days to look back for incremental sync."}
+                    }
+                },
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -88,6 +141,10 @@ class MCPServer:
             {
                 "name": "get_system_status",
                 "description": "Get current indexing status, total nodes in SQLite, and vector count in LanceDB.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {}
+                },
                 "parameters": {
                     "type": "object",
                     "properties": {}
@@ -101,7 +158,9 @@ class MCPServer:
                 task=args.get("task", ""),
                 query=args.get("query"),
                 scope=args.get("scope"),
-                max_nodes=args.get("max_nodes", 8)
+                max_nodes=args.get("max_nodes", 8),
+                target_date=args.get("target_date"),
+                temporal_mode=args.get("temporal_mode")
             )
             packet = self.context_builder.acquire_context(req)
             return {
@@ -109,14 +168,21 @@ class MCPServer:
                 "formatted_markdown": packet.formatted_context_markdown,
                 "node_count": len(packet.nodes),
                 "trace_id": packet.trace_id,
-                "latency_ms": packet.latency_ms
+                "latency_ms": packet.latency_ms,
+                "target_date": packet.target_date,
+                "temporal_mode": packet.temporal_mode,
+                "insufficient_evidence": packet.insufficient_evidence
             }
 
         elif name == "search_nodes":
             req = SemanticSearchRequest(
                 query=args.get("query", ""),
                 limit=args.get("limit", 10),
-                tag_filter=args.get("tag_filter")
+                tag_filter=args.get("tag_filter"),
+                target_date=args.get("target_date"),
+                date_from=args.get("date_from"),
+                date_to=args.get("date_to"),
+                temporal_mode=args.get("temporal_mode", "none")
             )
             resp = self.search_engine.search(req)
             return resp.model_dump()
@@ -179,7 +245,28 @@ class MCPServer:
                 msg_id = msg.get("id")
                 method = msg.get("method")
 
-                if method == "tools/list":
+                if method == "initialize":
+                    resp = {
+                        "jsonrpc": "2.0",
+                        "id": msg_id,
+                        "result": {
+                            "protocolVersion": msg.get("params", {}).get("protocolVersion", "2024-11-05"),
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "tana-context-mask", "version": "1.0.0"}
+                        }
+                    }
+                    sys.stdout.write(json.dumps(resp) + "\n")
+                    sys.stdout.flush()
+
+                elif method == "notifications/initialized":
+                    continue
+
+                elif method == "ping":
+                    resp = {"jsonrpc": "2.0", "id": msg_id, "result": {}}
+                    sys.stdout.write(json.dumps(resp) + "\n")
+                    sys.stdout.flush()
+
+                elif method == "tools/list":
                     resp = {
                         "jsonrpc": "2.0",
                         "id": msg_id,
@@ -209,10 +296,10 @@ class MCPServer:
                     sys.stdout.flush()
 
                 else:
-                    # Echo generic ack
-                    resp = {"jsonrpc": "2.0", "id": msg_id, "result": {}}
-                    sys.stdout.write(json.dumps(resp) + "\n")
-                    sys.stdout.flush()
+                    if msg_id is not None:
+                        resp = {"jsonrpc": "2.0", "id": msg_id, "result": {}}
+                        sys.stdout.write(json.dumps(resp) + "\n")
+                        sys.stdout.flush()
 
             except Exception as e:
                 err_resp = {
@@ -229,3 +316,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/tana_context_mask/engine/context_builder.py
+++ b/tana_context_mask/engine/context_builder.py
@@ -12,6 +12,7 @@ from ..models.search import SemanticSearchRequest
 from .semantic_search import SemanticSearchEngine
 from .graph_engine import GraphEngine
 from .reranker import TaskReranker
+from .temporal import parse_temporal_intent, classify_temporal_relationship
 
 class ContextBuilder:
     def __init__(
@@ -34,13 +35,31 @@ class ContextBuilder:
         task_text = request.task.strip()
         search_query = request.query.strip() if request.query else task_text
 
-        # 1. Whole-Workspace Semantic Discovery
+        # 0. Intent and Temporal Parameters
+        target_date = request.target_date
+        date_from = request.date_from
+        date_to = request.date_to
+        temporal_mode = request.temporal_mode or "none"
+
+        if temporal_mode == "none" and not target_date and not date_from and not date_to:
+            intent = parse_temporal_intent(search_query)
+            if intent["has_temporal_intent"] and intent["target_date"]:
+                target_date = intent["target_date"]
+                date_from = intent["date_from"]
+                date_to = intent["date_to"]
+                temporal_mode = intent["temporal_mode"]
+
+        # 1. Whole-Workspace Semantic Discovery with Temporal Gating
         search_req = SemanticSearchRequest(
             query=search_query,
-            limit=20,
+            limit=25,
             tag_filter=request.scope,
             hybrid=True,
-            alpha=settings.hybrid_alpha
+            alpha=settings.hybrid_alpha,
+            target_date=target_date,
+            date_from=date_from,
+            date_to=date_to,
+            temporal_mode=temporal_mode
         )
         search_resp = self.search_engine.search(search_req)
         
@@ -67,15 +86,19 @@ class ContextBuilder:
         # 3. Form Candidate Pool with Scores
         candidate_pool: List[Tuple[TanaNode, float, str]] = []
         for node, reason in expanded_pairs:
-            base_s = seed_scores.get(node.id, 0.40) # Default base score for graph neighbours
+            base_s = seed_scores.get(node.id, 0.40)
             candidate_pool.append((node, base_s, reason))
 
-        # 4. Multi-Factor Reranking & Deduplication
+        # 4. Multi-Factor Reranking & Deduplication with Temporal Anchoring
         max_nodes = request.max_nodes or settings.default_max_context_nodes
         ranked_candidates = self.reranker.rerank(
             task_query=task_text,
             candidates=candidate_pool,
-            max_nodes=max_nodes
+            max_nodes=max_nodes,
+            target_date=target_date,
+            date_from=date_from,
+            date_to=date_to,
+            temporal_mode=temporal_mode
         )
 
         # 5. Build Formatted Context Nodes & Markdown Packet
@@ -84,13 +107,19 @@ class ContextBuilder:
 
         md_sections.append(f"### 🌐 Tana Context Mask: Retrieved Knowledge Graph")
         md_sections.append(f"> **Task:** {task_text}")
+        if target_date:
+            md_sections.append(f"> **Target Date:** `{target_date}` | **Temporal Mode:** `{temporal_mode}`")
         md_sections.append(f"> **Trace ID:** `{trace_id}` | **Nodes Selected:** {len(ranked_candidates)} of {len(candidate_pool)} evaluated\n")
 
+        if search_resp.insufficient_evidence:
+            md_sections.append("> ⚠️ **Notice:** Insufficient contemporaneous evidence found in Tana for the requested historical period.\n")
+
+        # Group nodes by temporal classification if temporal intent active
+        target_year = target_date[:4] if target_date else None
+
         for idx, (node, score, reason) in enumerate(ranked_candidates, start=1):
-            # Resolve fields
             fields_dict = {f.field_name: (f.value_text or f.value_node_id) for f in node.fields}
             
-            # Resolve child snippets if requested
             child_snippets: List[str] = []
             if request.include_children and node.children:
                 child_nodes = self.db.get_children(node.id, limit=6)
@@ -101,6 +130,12 @@ class ContextBuilder:
                         child_snippets.append(f"{clean_cname}{done_mark}")
 
             tags_list = [t.tag_name for t in node.supertags]
+
+            rel_class = classify_temporal_relationship(
+                node=node,
+                target_date_str=target_date,
+                target_year=target_year
+            )
 
             ctx_node = ContextNode(
                 id=node.id,
@@ -114,7 +149,10 @@ class ContextBuilder:
                 backlinks=node.backlinks,
                 inclusion_reason=reason,
                 relevance_score=score,
-                deep_link=node.deep_link
+                deep_link=node.deep_link,
+                effective_date=node.effective_date,
+                date_source=node.date_source,
+                temporal_relationship=rel_class
             )
             context_nodes.append(ctx_node)
 
@@ -122,11 +160,22 @@ class ContextBuilder:
             tags_badge = " ".join([f"`#{t}`" for t in tags_list]) if tags_list else ""
             crumb_path = " › ".join(node.breadcrumbs) if node.breadcrumbs else "Workspace Root"
             
+            # Temporal badge
+            rel_badge = ""
+            if rel_class == "contemporaneous":
+                rel_badge = f" `[Contemporaneous · {node.effective_date or 'verified'}]`"
+            elif rel_class == "retrospective":
+                rel_badge = f" `[Retrospective · recorded {node.effective_date or 'later'}]`"
+            elif rel_class == "conflicting":
+                rel_badge = " `[Conflicting Date]`"
+
             md_item = []
-            md_item.append(f"#### {idx}. [{node.name}]({node.deep_link}) {tags_badge}")
+            md_item.append(f"#### {idx}. [{node.name}]({node.deep_link}) {tags_badge}{rel_badge}")
             md_item.append(f"- **Tana ID:** `tana:{node.id}` | **Relevance:** {score:.2f}")
             md_item.append(f"- **Path:** `{crumb_path}`")
             md_item.append(f"- **Why included:** {reason}")
+            if node.effective_date:
+                md_item.append(f"- **Calendar Provenance:** `{node.effective_date}` (source: `{node.date_source}`)")
             
             if node.description:
                 md_item.append(f"- **Description:** {node.description}")
@@ -171,5 +220,8 @@ class ContextBuilder:
             total_candidates_examined=len(candidate_pool),
             graph_expansion_count=len(expanded_pairs) - len(seed_nodes),
             latency_ms=total_latency_ms,
-            timestamp=datetime.now().isoformat()
+            timestamp=datetime.now().isoformat(),
+            target_date=target_date,
+            temporal_mode=temporal_mode,
+            insufficient_evidence=search_resp.insufficient_evidence
         )

--- a/tana_context_mask/engine/reranker.py
+++ b/tana_context_mask/engine/reranker.py
@@ -2,6 +2,7 @@ import math
 from datetime import datetime
 from typing import List, Dict, Tuple, Any, Optional
 from ..models.node import TanaNode
+from .temporal import compute_temporal_score, classify_temporal_relationship, is_day_node
 
 class TaskReranker:
     def __init__(self):
@@ -11,13 +12,17 @@ class TaskReranker:
         self,
         task_query: str,
         candidates: List[Tuple[TanaNode, float, str]],  # (node, base_score, inclusion_reason)
-        max_nodes: int = 8
+        max_nodes: int = 8,
+        target_date: Optional[str] = None,
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None,
+        temporal_mode: str = "none"
     ) -> List[Tuple[TanaNode, float, str]]:
         """
         Reranks expanded node candidates according to multi-factor relevance:
         - Base semantic/lexical similarity
         - Graph centrality and structural connectivity
-        - Temporal recency decay
+        - Temporal proximity (when target_date / history mode active) or recency decay (general queries)
         - Tag importance and content completeness
         """
         if not candidates:
@@ -27,12 +32,12 @@ class TaskReranker:
         scored_candidates: List[Tuple[TanaNode, float, str]] = []
 
         now = datetime.now().timestamp()
+        target_year = target_date[:4] if target_date else (date_from[:4] if date_from else None)
 
         for node, base_score, reason in candidates:
             score = base_score
 
             # 1. Graph Connectivity Bonus
-            # If the node's parent or children or references are also in the candidate set, it is part of a relevant cluster
             cluster_connections = 0
             if node.parent_id in all_candidate_ids:
                 cluster_connections += 1
@@ -46,34 +51,60 @@ class TaskReranker:
             if cluster_connections > 0:
                 score += min(0.25, cluster_connections * 0.08)
 
-            # 2. Recency Bonus
-            if node.updated_at:
-                try:
-                    # ISO string parsing
-                    updated_ts = datetime.fromisoformat(node.updated_at.replace("Z", "+00:00")).timestamp()
-                    days_old = max(0, (now - updated_ts) / 86400.0)
-                    # Exponential decay: e^(-days/180) -> up to 0.1 bonus for recent nodes
-                    recency_boost = 0.10 * math.exp(-days_old / 180.0)
-                    score += recency_boost
-                except Exception:
-                    pass
+            # 2. Temporal Handling
+            if target_date or (temporal_mode in ["strict", "boost", "filter"]):
+                temp_score = compute_temporal_score(
+                    node_date_str=node.effective_date,
+                    target_date_str=target_date,
+                    date_from_str=date_from,
+                    date_to_str=date_to
+                )
+                rel_class = classify_temporal_relationship(
+                    node=node,
+                    target_date_str=target_date,
+                    target_year=target_year
+                )
+
+                if temporal_mode == "strict":
+                    if rel_class == "contemporaneous":
+                        score += 0.30 + (temp_score * 0.20)
+                    elif rel_class == "retrospective":
+                        score -= 0.50  # Strong demotion so contemporary evidence dominates
+                    elif rel_class == "conflicting":
+                        score -= 0.60
+                    else:
+                        score -= 0.40
+                elif temporal_mode == "boost":
+                    score = (score * 0.60) + (temp_score * 0.40)
+            else:
+                # General query: Recent updates get small bonus
+                if node.updated_at:
+                    try:
+                        updated_ts = datetime.fromisoformat(node.updated_at.replace("Z", "+00:00")).timestamp()
+                        days_old = max(0, (now - updated_ts) / 86400.0)
+                        recency_boost = 0.10 * math.exp(-days_old / 180.0)
+                        score += recency_boost
+                    except Exception:
+                        pass
 
             # 3. Structural Significance Bonus (Supertags)
             tag_names = [t.tag_name.lower() for t in node.supertags]
             if any(t in tag_names for t in ["project", "goal", "task", "milestone", "meeting", "sprint"]):
                 score += 0.08
 
-            # 4. Penalise very short or trivial nodes without context
-            if len(node.name.strip()) < 4 and not node.description and not node.fields:
-                score *= 0.6
+            # 4. Bare calendar container demotion & penalty for trivial nodes
+            is_bare_cal, _ = is_day_node(node)
+            if is_bare_cal and not node.description and not node.fields:
+                score *= 0.40
+            elif len(node.name.strip()) < 4 and not node.description and not node.fields:
+                score *= 0.60
 
             scored_candidates.append((node, round(score, 4), reason))
 
         # Sort descending by composite score
         scored_candidates.sort(key=lambda x: x[1], reverse=True)
 
-        # Deduplication: prune only exact duplicate leaves sharing the same parent container
-        # Preserves minority evidence, divergent decisions, and contradictions across different areas (Grill-Me #11)
+        # Deduplication
         seen_keys = set()
         deduped: List[Tuple[TanaNode, float, str]] = []
         for node, s, r in scored_candidates:

--- a/tana_context_mask/engine/semantic_search.py
+++ b/tana_context_mask/engine/semantic_search.py
@@ -1,10 +1,17 @@
 import time
+from datetime import datetime, date, timedelta
 from typing import List, Dict, Optional, Tuple, Any
 from ..config import settings
 from ..storage.db import SQLiteStore
 from ..storage.vector_store import VectorStore
 from ..models.search import SemanticSearchRequest, SearchResultItem, SearchResponse
 from ..models.node import TanaNode
+from .temporal import (
+    compute_temporal_score,
+    classify_temporal_relationship,
+    parse_temporal_intent,
+    is_day_node
+)
 
 class SemanticSearchEngine:
     def __init__(self, db: Optional[SQLiteStore] = None, vector_store: Optional[VectorStore] = None):
@@ -20,38 +27,110 @@ class SemanticSearchEngine:
         limit = request.limit or settings.default_top_k
         alpha = request.alpha if request.alpha is not None else settings.hybrid_alpha
 
-        # 1. Vector Semantic Search
-        vector_hits = self.vector_store.search(query, limit=limit * 2)
-        vector_scores: Dict[str, float] = {h["id"]: float(h["score"]) for h in vector_hits}
+        # 0. Intent and Temporal Parameters Resolution
+        target_date = request.target_date
+        date_from = request.date_from
+        date_to = request.date_to
+        temporal_mode = request.temporal_mode or "none"
+        temporal_weight = request.temporal_weight if request.temporal_weight is not None else 0.40
 
-        # 2. FTS Lexical Search
-        fts_hits = self.db.fts_search(query, limit=limit * 2, tag_filter=request.tag_filter)
-        lexical_scores: Dict[str, float] = {node.id: score for node, score in fts_hits}
+        # Automatic historical intent detection if not explicitly configured
+        if temporal_mode == "none" and not target_date and not date_from and not date_to:
+            intent = parse_temporal_intent(query)
+            if intent["has_temporal_intent"] and intent["target_date"]:
+                target_date = intent["target_date"]
+                date_from = intent["date_from"]
+                date_to = intent["date_to"]
+                temporal_mode = intent["temporal_mode"]
 
-        # 3. Combine Candidates
-        all_candidate_ids = set(vector_scores.keys()).union(set(lexical_scores.keys()))
-        combined_scores: List[Tuple[str, float, float, float]] = [] # (id, final_score, sem_score, lex_score)
+        # 1. Candidate Generation
+        candidate_nodes: Dict[str, TanaNode] = {}
+        vector_scores: Dict[str, float] = {}
+        lexical_scores: Dict[str, float] = {}
+
+        # Strategy A: Calendar-First Candidate Generation for Strict/Filter Historical Queries
+        if temporal_mode in ["strict", "filter"] and (target_date or date_from or date_to):
+            # Define search window (default initial ±7 days around target_date if bounds not set)
+            if target_date and (not date_from or not date_to):
+                try:
+                    t_d = datetime.strptime(target_date[:10], "%Y-%m-%d").date()
+                    w_from = (t_d - timedelta(days=7)).isoformat()
+                    w_to = (t_d + timedelta(days=7)).isoformat()
+                except ValueError:
+                    w_from = date_from or target_date
+                    w_to = date_to or target_date
+            else:
+                w_from = date_from or target_date
+                w_to = date_to or target_date
+
+            # Initial window collection
+            cal_nodes = self.db.get_nodes_by_date_range(w_from, w_to, limit=200)
+
+            # Progressive window widening if coverage is sparse (±14d, ±30d, ±60d)
+            if len(cal_nodes) < 3 and target_date:
+                for widen_days in [14, 30, 60]:
+                    try:
+                        t_d = datetime.strptime(target_date[:10], "%Y-%m-%d").date()
+                        w_from = (t_d - timedelta(days=widen_days)).isoformat()
+                        w_to = (t_d + timedelta(days=widen_days)).isoformat()
+                        cal_nodes = self.db.get_nodes_by_date_range(w_from, w_to, limit=200)
+                        if len(cal_nodes) >= 3:
+                            break
+                    except ValueError:
+                        break
+
+            for cn in cal_nodes:
+                candidate_nodes[cn.id] = cn
+
+        # Strategy B: Global Semantic + Lexical Retrieval
+        # Vector Semantic Search
+        vector_hits = self.vector_store.search(query, limit=limit * 4)
+        for h in vector_hits:
+            vector_scores[h["id"]] = float(h["score"])
+
+        # FTS Lexical Search
+        fts_hits = self.db.fts_search(query, limit=limit * 4, tag_filter=request.tag_filter)
+        for node, score in fts_hits:
+            lexical_scores[node.id] = score
+            if node.id not in candidate_nodes:
+                candidate_nodes[node.id] = node
+
+        # If we have calendar-first candidates, ensure their vector scores are computed
+        query_vec = None
+        for cid, cnode in candidate_nodes.items():
+            if cid not in vector_scores:
+                if query_vec is None:
+                    query_vec = self.vector_store.embed_text(query)
+                # Compute on-demand vector similarity
+                c_vec = self.vector_store.embed_text(cnode.full_searchable_text or cnode.name)
+                # Cosine similarity
+                import numpy as np
+                qv = np.array(query_vec, dtype=np.float32)
+                cv = np.array(c_vec, dtype=np.float32)
+                norm_q = np.linalg.norm(qv)
+                norm_c = np.linalg.norm(cv)
+                if norm_q > 0 and norm_c > 0:
+                    sim = float(np.dot(qv, cv) / (norm_q * norm_c))
+                    vector_scores[cid] = max(0.0, min(1.0, (sim + 1.0) / 2.0))
+                else:
+                    vector_scores[cid] = 0.0
+
+        all_candidate_ids = set(candidate_nodes.keys()).union(set(vector_scores.keys())).union(set(lexical_scores.keys()))
+
+        # Pre-fetch nodes from DB for any missing candidate IDs
+        missing_ids = [cid for cid in all_candidate_ids if cid not in candidate_nodes]
+        if missing_ids:
+            hydrated = self.db.get_nodes(missing_ids)
+            for h in hydrated:
+                candidate_nodes[h.id] = h
+
+        scored_candidates: List[Tuple[TanaNode, float, float, float, float, str]] = []
+        # (node, final_score, base_score, sem_score, lex_score, rel_classification)
+
+        target_year = target_date[:4] if target_date else (date_from[:4] if date_from else None)
 
         for cid in all_candidate_ids:
-            s_score = vector_scores.get(cid, 0.0)
-            l_score = lexical_scores.get(cid, 0.0)
-            
-            if request.hybrid:
-                # Weighted hybrid combination
-                final_score = (alpha * s_score) + ((1.0 - alpha) * l_score)
-            else:
-                final_score = s_score
-
-            combined_scores.append((cid, final_score, s_score, l_score))
-
-        # Sort by final score descending
-        combined_scores.sort(key=lambda x: x[1], reverse=True)
-        top_candidates = combined_scores[:limit]
-
-        # 4. Hydrate full nodes and construct response items
-        results: List[SearchResultItem] = []
-        for cid, f_score, s_score, l_score in top_candidates:
-            node = self.db.get_node(cid)
+            node = candidate_nodes.get(cid)
             if not node or node.in_trash:
                 continue
 
@@ -61,23 +140,119 @@ class SemanticSearchEngine:
                 if not any(request.tag_filter.lower() in tn for tn in node_tag_names):
                     continue
 
+            s_score = vector_scores.get(cid, 0.0)
+            l_score = lexical_scores.get(cid, 0.0)
+
+            # Base hybrid score
+            if request.hybrid:
+                base_score = (alpha * s_score) + ((1.0 - alpha) * l_score)
+            else:
+                base_score = s_score
+
+            # Temporal proximity score and relationship classification
+            temp_score = compute_temporal_score(
+                node_date_str=node.effective_date,
+                target_date_str=target_date,
+                date_from_str=date_from,
+                date_to_str=date_to
+            )
+
+            rel_class = classify_temporal_relationship(
+                node=node,
+                target_date_str=target_date,
+                target_year=target_year
+            )
+
+            # Apply Temporal Mode Logic
+            if temporal_mode == "none":
+                final_score = base_score
+
+            elif temporal_mode == "boost":
+                # Multi-factor proximity fusion
+                final_score = ((1.0 - temporal_weight) * base_score) + (temporal_weight * temp_score)
+
+            elif temporal_mode == "filter":
+                # Exclude candidates outside range or without date
+                if not node.effective_date or temp_score <= 0.0:
+                    continue
+                if date_from and node.effective_date < date_from:
+                    continue
+                if date_to and node.effective_date > date_to:
+                    continue
+                final_score = base_score
+
+            elif temporal_mode == "strict":
+                # Invariant: Must have verified calendar/occurrence date in period
+                # Weak fallbacks or undated/conflicting are rejected from strict evidence
+                if not node.effective_date or node.date_source not in ["day_node", "field", "explicit_rel"]:
+                    continue
+
+                if rel_class == "conflicting":
+                    continue
+
+                # Wrong-year Day-node descendants talking about the target period are retrospective
+                if rel_class == "retrospective":
+                    continue
+
+                if target_year and node.effective_date[:4] != target_year:
+                    continue
+
+                if date_from and node.effective_date < date_from:
+                    continue
+                if date_to and node.effective_date > date_to:
+                    continue
+
+                final_score = (base_score * 0.70) + (temp_score * 0.30)
+
+            else:
+                final_score = base_score
+
+            # Bare calendar date containers get demoted relative to substantive content notes
+            is_bare_cal, _ = is_day_node(node)
+            if is_bare_cal and not node.description and not node.fields:
+                final_score *= 0.50
+            elif node.description or node.fields:
+                final_score += 0.05
+
+            scored_candidates.append((node, final_score, base_score, s_score, temp_score, rel_class))
+
+        # Sort by final score descending
+        scored_candidates.sort(key=lambda x: x[1], reverse=True)
+        top_candidates = scored_candidates[:limit]
+
+        results: List[SearchResultItem] = []
+        for node, f_score, b_score, s_score, t_score, rel_class in top_candidates:
             results.append(SearchResultItem(
                 id=node.id,
                 name=node.name,
                 description=node.description or "",
                 score=round(f_score, 4),
                 semantic_score=round(s_score, 4),
-                lexical_score=round(l_score, 4),
+                lexical_score=round(b_score, 4),
                 breadcrumbs=node.breadcrumbs,
                 tags=[t.tag_name for t in node.supertags],
                 parent_id=node.parent_id,
-                last_updated=node.updated_at
+                last_updated=node.updated_at,
+                effective_date=node.effective_date,
+                date_source=node.date_source,
+                date_source_node_id=node.date_source_node_id,
+                calendar_path=node.calendar_path,
+                ancestor_day_node_id=node.ancestor_day_node_id,
+                ancestor_month_node_id=node.ancestor_month_node_id,
+                ancestor_year_node_id=node.ancestor_year_node_id,
+                temporal_relationship=rel_class,
+                temporal_score=round(t_score, 4)
             ))
 
         latency_ms = round((time.time() - start_t) * 1000.0, 2)
+        insufficient = (len(results) == 0 and temporal_mode == "strict" and target_date is not None)
+
         return SearchResponse(
             query=query,
             total_hits=len(results),
             results=results,
-            latency_ms=latency_ms
+            latency_ms=latency_ms,
+            target_date=target_date,
+            temporal_mode=temporal_mode,
+            insufficient_evidence=insufficient
         )

--- a/tana_context_mask/engine/temporal.py
+++ b/tana_context_mask/engine/temporal.py
@@ -1,0 +1,448 @@
+import re
+import math
+from datetime import datetime, date, timedelta
+from typing import Optional, List, Dict, Tuple, Any
+from ..models.node import TanaNode, NodeTag, NodeField
+
+MONTH_NAMES = {
+    "january": 1, "jan": 1,
+    "february": 2, "feb": 2,
+    "march": 3, "mar": 3,
+    "april": 4, "apr": 4,
+    "may": 5,
+    "june": 6, "jun": 6,
+    "july": 7, "jul": 7,
+    "august": 8, "aug": 8,
+    "september": 9, "sep": 9, "sept": 9,
+    "october": 10, "oct": 10,
+    "november": 11, "nov": 11,
+    "december": 12, "dec": 12
+}
+
+DATE_FIELD_NAMES = {
+    "date", "due date", "event date", "when", "occurrence date",
+    "original date", "scheduled date", "start date", "target date"
+}
+
+def parse_iso_date(text: str) -> Optional[str]:
+    """Extracts YYYY-MM-DD from a text string if present."""
+    if not text:
+        return None
+    # 1. Matches YYYY-MM-DD
+    m = re.search(r'\b(19\d\d|20\d\d)-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])\b', text)
+    if m:
+        return m.group(0)
+    
+    # 2. Matches "1 September 2019", "September 1, 2019", "Sep 1 2019", "1st Sep 2019"
+    months_pattern = r'(?:' + '|'.join(MONTH_NAMES.keys()) + r')'
+    m2 = re.search(rf'\b({months_pattern})\s+(\d{{1,2}})(?:st|nd|rd|th)?(?:,)?\s+(19\d\d|20\d\d)\b', text, re.IGNORECASE)
+    if m2:
+        m_str, d_str, y_str = m2.group(1).lower(), m2.group(2), m2.group(3)
+        month = MONTH_NAMES.get(m_str, 1)
+        day = int(d_str)
+        return f"{int(y_str):04d}-{month:02d}-{day:02d}"
+
+    m3 = re.search(rf'\b(\d{{1,2}})(?:st|nd|rd|th)?\s+({months_pattern})\s+(19\d\d|20\d\d)\b', text, re.IGNORECASE)
+    if m3:
+        d_str, m_str, y_str = m3.group(1), m3.group(2).lower(), m3.group(3)
+        month = MONTH_NAMES.get(m_str, 1)
+        day = int(d_str)
+        return f"{int(y_str):04d}-{month:02d}-{day:02d}"
+
+    return None
+
+def is_day_node(node: TanaNode) -> Tuple[bool, Optional[str]]:
+    """Checks if node is a Day calendar node and extracts its date string."""
+    # Tag check (e.g. tag_name "Day" or tag_id "1Kcq0q_pf5Fn")
+    tag_names = [t.tag_name.lower() for t in node.supertags]
+    tag_ids = [t.tag_id for t in node.supertags]
+    has_day_tag = ("day" in tag_names or "1Kcq0q_pf5Fn" in tag_ids)
+
+    # Clean name
+    clean_name = re.sub(r'<[^>]+>', '', node.name).strip()
+    parsed_date = parse_iso_date(clean_name)
+
+    if parsed_date:
+        return True, parsed_date
+    if has_day_tag:
+        # If tagged Day but name didn't directly match regex, check created_at or node fields
+        field_date = parse_field_date(node)
+        if field_date:
+            return True, field_date
+        if node.created_at:
+            c_date = parse_iso_date(node.created_at)
+            if c_date:
+                return True, c_date
+    return False, None
+
+def is_month_node(node: TanaNode) -> Tuple[bool, Optional[str]]:
+    """Checks if node represents a Month calendar node (e.g. 'September 2019' or '2019-09')."""
+    clean_name = re.sub(r'<[^>]+>', '', node.name).strip()
+    months_pattern = r'(?:' + '|'.join(MONTH_NAMES.keys()) + r')'
+    
+    m = re.search(rf'\b({months_pattern})\s+(19\d\d|20\d\d)\b', clean_name, re.IGNORECASE)
+    if m:
+        m_str, y_str = m.group(1).lower(), m.group(2)
+        month = MONTH_NAMES.get(m_str, 1)
+        return True, f"{int(y_str):04d}-{month:02d}"
+
+    m2 = re.search(r'\b(19\d\d|20\d\d)-(0[1-9]|1[0-2])\b', clean_name)
+    if m2:
+        return True, f"{m2.group(1)}-{m2.group(2)}"
+
+    tag_names = [t.tag_name.lower() for t in node.supertags]
+    if "month" in tag_names:
+        return True, None
+    return False, None
+
+def is_year_node(node: TanaNode) -> Tuple[bool, Optional[str]]:
+    """Checks if node represents a Year calendar node (e.g. '2019')."""
+    clean_name = re.sub(r'<[^>]+>', '', node.name).strip()
+    m = re.fullmatch(r'(19\d\d|20\d\d)(?:\s+Year)?', clean_name, re.IGNORECASE)
+    if m:
+        return True, m.group(1)
+    tag_names = [t.tag_name.lower() for t in node.supertags]
+    if "year" in tag_names:
+        return True, None
+    return False, None
+
+def parse_field_date(node: TanaNode) -> Optional[str]:
+    """Finds explicit date field on the node."""
+    for field in node.fields:
+        f_name = field.field_name.lower().strip()
+        if f_name in DATE_FIELD_NAMES or "date" in f_name or "when" in f_name:
+            val = (field.value_text or "").strip()
+            parsed = parse_iso_date(val)
+            if parsed:
+                return parsed
+    return None
+
+def resolve_node_provenance(node: TanaNode, parent_chain: List[TanaNode]) -> Dict[str, Any]:
+    """
+    Derives effective_date and calendar lineage for a node according to precedence:
+    1. Nearest ancestor Day/calendar node
+    2. Explicit date field on node
+    3. Other explicit calendar relationship
+    4. Created timestamp (weak fallback)
+    """
+    # Check if the node itself is a Day node
+    self_is_day, self_day_date = is_day_node(node)
+    if self_is_day and self_day_date:
+        return {
+            "effective_date": self_day_date,
+            "date_source": "day_node",
+            "date_source_node_id": node.id,
+            "calendar_distance": 0,
+            "calendar_path": self_day_date,
+            "ancestor_day_node_id": node.id,
+            "ancestor_week_node_id": None,
+            "ancestor_month_node_id": None,
+            "ancestor_year_node_id": self_day_date[:4]
+        }
+
+    # 1. Search parent chain for nearest Day/calendar ancestor
+    ancestor_day_id = None
+    ancestor_day_date = None
+    ancestor_month_id = None
+    ancestor_year_id = None
+    calendar_distance = None
+
+    for dist, p in enumerate(parent_chain, start=1):
+        p_is_day, p_day_date = is_day_node(p)
+        if p_is_day and p_day_date:
+            if ancestor_day_id is None:
+                ancestor_day_id = p.id
+                ancestor_day_date = p_day_date
+                calendar_distance = dist
+
+        p_is_month, _ = is_month_node(p)
+        if p_is_month and ancestor_month_id is None:
+            ancestor_month_id = p.id
+
+        p_is_year, p_year = is_year_node(p)
+        if p_is_year and ancestor_year_id is None:
+            ancestor_year_id = p.id
+
+    explicit_field_date = parse_field_date(node)
+
+    # 1. Ancestor Day node has highest precedence for historical grounding
+    if ancestor_day_date:
+        cal_path = ancestor_day_date
+        year_str = ancestor_day_date[:4]
+        return {
+            "effective_date": ancestor_day_date,
+            "date_source": "day_node",
+            "date_source_node_id": ancestor_day_id,
+            "calendar_distance": calendar_distance,
+            "calendar_path": cal_path,
+            "ancestor_day_node_id": ancestor_day_id,
+            "ancestor_week_node_id": None,
+            "ancestor_month_node_id": ancestor_month_id,
+            "ancestor_year_node_id": ancestor_year_id or year_str
+        }
+
+    # 2. Explicit date field
+    if explicit_field_date:
+        return {
+            "effective_date": explicit_field_date,
+            "date_source": "field",
+            "date_source_node_id": node.id,
+            "calendar_distance": 0,
+            "calendar_path": explicit_field_date,
+            "ancestor_day_node_id": None,
+            "ancestor_week_node_id": None,
+            "ancestor_month_node_id": ancestor_month_id,
+            "ancestor_year_node_id": explicit_field_date[:4]
+        }
+
+    # 3. Created timestamp fallback (weak)
+    if node.created_at:
+        c_date = parse_iso_date(node.created_at)
+        if c_date:
+            return {
+                "effective_date": c_date,
+                "date_source": "fallback_created",
+                "date_source_node_id": node.id,
+                "calendar_distance": None,
+                "calendar_path": c_date,
+                "ancestor_day_node_id": None,
+                "ancestor_week_node_id": None,
+                "ancestor_month_node_id": None,
+                "ancestor_year_node_id": c_date[:4]
+            }
+
+    # 4. Undated
+    return {
+        "effective_date": None,
+        "date_source": "none",
+        "date_source_node_id": None,
+        "calendar_distance": None,
+        "calendar_path": None,
+        "ancestor_day_node_id": None,
+        "ancestor_week_node_id": None,
+        "ancestor_month_node_id": None,
+        "ancestor_year_node_id": None
+    }
+
+def compute_temporal_score(
+    node_date_str: Optional[str],
+    target_date_str: Optional[str],
+    date_from_str: Optional[str] = None,
+    date_to_str: Optional[str] = None
+) -> float:
+    """
+    Computes temporal proximity score in [0.0, 1.0].
+    0 days = 1.00, 1 day = 0.95, 3 days = 0.85, 7 days = 0.70, 14 days = 0.50, 30 days = 0.25, >30 days = decay
+    """
+    if not node_date_str:
+        return 0.0
+
+    try:
+        n_date = datetime.strptime(node_date_str[:10], "%Y-%m-%d").date()
+    except ValueError:
+        return 0.0
+
+    # Range filter bounds check
+    if date_from_str:
+        try:
+            d_from = datetime.strptime(date_from_str[:10], "%Y-%m-%d").date()
+            if n_date < d_from:
+                return 0.0
+        except ValueError:
+            pass
+
+    if date_to_str:
+        try:
+            d_to = datetime.strptime(date_to_str[:10], "%Y-%m-%d").date()
+            if n_date > d_to:
+                return 0.0
+        except ValueError:
+            pass
+
+    if not target_date_str:
+        return 1.0  # Inside range without specific target
+
+    try:
+        t_date = datetime.strptime(target_date_str[:10], "%Y-%m-%d").date()
+    except ValueError:
+        return 0.5
+
+    delta_days = abs((n_date - t_date).days)
+
+    # Standard piecewise decay schedule
+    if delta_days == 0:
+        return 1.00
+    elif delta_days == 1:
+        return 0.95
+    elif delta_days <= 3:
+        return 0.85
+    elif delta_days <= 7:
+        return 0.70
+    elif delta_days <= 14:
+        return 0.50
+    elif delta_days <= 30:
+        return 0.25
+    else:
+        # Exponential tail decay
+        return max(0.0, 0.25 * math.exp(-(delta_days - 30) / 60.0))
+
+def classify_temporal_relationship(
+    node: TanaNode,
+    target_date_str: Optional[str] = None,
+    target_year: Optional[str] = None
+) -> str:
+    """
+    Classifies the node's temporal relationship into:
+    - 'contemporaneous'
+    - 'retrospective'
+    - 'undated'
+    - 'conflicting'
+    """
+    field_date = parse_field_date(node)
+    
+    # Check for conflict: explicit field date year != Day node year
+    if field_date and node.effective_date and node.date_source == "day_node":
+        if field_date[:4] != node.effective_date[:4]:
+            return "conflicting"
+
+    # Extract any year mentioned in the plain text
+    full_text = f"{node.name} {node.description or ''}".lower()
+    text_years = re.findall(r'\b(19\d\d|20\d\d)\b', full_text)
+
+    # Target reference year
+    ref_year = target_year or (target_date_str[:4] if target_date_str else None)
+
+    # If the node is under a Day node of a different year (e.g. 2026) but talks about the target year (e.g. 2019)
+    if node.effective_date and ref_year:
+        node_year = node.effective_date[:4]
+        if node_year != ref_year and ref_year in text_years:
+            return "retrospective"
+
+        if node_year == ref_year:
+            if node.date_source in ["day_node", "field", "explicit_rel"]:
+                return "contemporaneous"
+            elif node.date_source == "fallback_created":
+                return "contemporaneous"
+
+    # If node has no valid date provenance but mentions the target year
+    if not node.effective_date or node.date_source == "none":
+        return "undated"
+
+    return "contemporaneous"
+
+def parse_temporal_intent(
+    query_text: str,
+    reference_date: Optional[date] = None
+) -> Dict[str, Any]:
+    """
+    Detects historical / autobiographical intent and extracts target date/ranges.
+    Examples:
+    - "What was I doing this time in 2019?" (on 2026-09-01 -> target_date: 2019-09-01)
+    - "What was happening around September 2018?" -> target_date: 2018-09-15, date_from: 2018-09-01, date_to: 2018-09-30
+    - "What was I working on during 2019?" -> target_date: 2019-07-01, date_from: 2019-01-01, date_to: 2019-12-31
+    - "What was going on around this date last year?" -> target_date: <last year same date>
+    """
+    ref = reference_date or date.today()
+    q = query_text.strip()
+    q_lower = q.lower()
+
+    temporal_indicators = [
+        r'this time in (\d{4})',
+        r'around (?:the\s+)?(\d{1,2}(?:st|nd|rd|th)?\s+)?([a-z]+)\s+(\d{4})',
+        r'in ([a-z]+)\s+(\d{4})',
+        r'during (\d{4})',
+        r'back in (\d{4})',
+        r'in (\d{4})',
+        r'last year',
+        r'(\d+)\s+years ago',
+        r'around this date last year',
+        r'what was i doing',
+        r'what was happening',
+        r'when was i',
+        r'at that time'
+    ]
+
+    has_intent = False
+    for pat in temporal_indicators:
+        if re.search(pat, q_lower):
+            has_intent = True
+            break
+
+    target_date = None
+    date_from = None
+    date_to = None
+    temporal_mode = "none"
+
+    if has_intent:
+        temporal_mode = "strict"
+
+        # 1. "this time in YYYY" / "around this time in YYYY"
+        m_this_time = re.search(r'(?:around\s+)?this time (?:in|of)\s+(\d{4})', q_lower)
+        if m_this_time:
+            yr = int(m_this_time.group(1))
+            try:
+                t_d = date(yr, ref.month, ref.day)
+            except ValueError:
+                t_d = date(yr, ref.month, 28)
+            target_date = t_d.isoformat()
+            date_from = (t_d - timedelta(days=14)).isoformat()
+            date_to = (t_d + timedelta(days=14)).isoformat()
+
+        # 2. "around [Month] [YYYY]" or "in [Month] [YYYY]"
+        months_pattern = r'(?:' + '|'.join(MONTH_NAMES.keys()) + r')'
+        m_month_yr = re.search(rf'(?:around|in|during)\s+({months_pattern})\s+(\d{{4}})', q_lower)
+        if not target_date and m_month_yr:
+            m_str, y_str = m_month_yr.group(1).lower(), m_month_yr.group(2)
+            month = MONTH_NAMES.get(m_str, 1)
+            yr = int(y_str)
+            target_date = f"{yr:04d}-{month:02d}-15"
+            date_from = f"{yr:04d}-{month:02d}-01"
+            # End of month
+            if month in [1, 3, 5, 7, 8, 10, 12]:
+                last_day = 31
+            elif month in [4, 6, 9, 11]:
+                last_day = 30
+            else:
+                last_day = 29 if (yr % 4 == 0 and (yr % 100 != 0 or yr % 400 == 0)) else 28
+            date_to = f"{yr:04d}-{month:02d}-{last_day:02d}"
+
+        # 3. "during YYYY" or "in YYYY" or "back in YYYY"
+        m_yr = re.search(r'(?:during|in|back in|around)\s+(\d{4})', q_lower)
+        if not target_date and m_yr:
+            yr = int(m_yr.group(1))
+            target_date = f"{yr:04d}-07-01"
+            date_from = f"{yr:04d}-01-01"
+            date_to = f"{yr:04d}-12-31"
+
+        # 4. "last year" or "around this date last year"
+        if not target_date and ("last year" in q_lower or "around this date last year" in q_lower):
+            yr = ref.year - 1
+            try:
+                t_d = date(yr, ref.month, ref.day)
+            except ValueError:
+                t_d = date(yr, ref.month, 28)
+            target_date = t_d.isoformat()
+            date_from = (t_d - timedelta(days=14)).isoformat()
+            date_to = (t_d + timedelta(days=14)).isoformat()
+
+        # 5. "X years ago"
+        m_ago = re.search(r'(\d+)\s+years ago', q_lower)
+        if not target_date and m_ago:
+            yr_diff = int(m_ago.group(1))
+            yr = ref.year - yr_diff
+            try:
+                t_d = date(yr, ref.month, ref.day)
+            except ValueError:
+                t_d = date(yr, ref.month, 28)
+            target_date = t_d.isoformat()
+            date_from = (t_d - timedelta(days=14)).isoformat()
+            date_to = (t_d + timedelta(days=14)).isoformat()
+
+    return {
+        "has_temporal_intent": has_intent,
+        "target_date": target_date,
+        "date_from": date_from,
+        "date_to": date_to,
+        "temporal_mode": temporal_mode,
+        "cleaned_query": q
+    }

--- a/tana_context_mask/models/context.py
+++ b/tana_context_mask/models/context.py
@@ -8,6 +8,10 @@ class ContextAcquisitionRequest(BaseModel):
     max_nodes: int = 8
     include_children: bool = True
     include_references: bool = True
+    target_date: Optional[str] = None
+    date_from: Optional[str] = None
+    date_to: Optional[str] = None
+    temporal_mode: Optional[str] = None
 
 class ContextNode(BaseModel):
     id: str
@@ -22,6 +26,9 @@ class ContextNode(BaseModel):
     inclusion_reason: str = ""
     relevance_score: float = 0.0
     deep_link: str = ""
+    effective_date: Optional[str] = None
+    date_source: Optional[str] = None
+    temporal_relationship: Optional[str] = None
 
 class ContextPacket(BaseModel):
     trace_id: str
@@ -33,6 +40,9 @@ class ContextPacket(BaseModel):
     graph_expansion_count: int
     latency_ms: float
     timestamp: str
+    target_date: Optional[str] = None
+    temporal_mode: Optional[str] = None
+    insufficient_evidence: bool = False
 
 class TraceRecord(BaseModel):
     trace_id: str

--- a/tana_context_mask/models/node.py
+++ b/tana_context_mask/models/node.py
@@ -39,6 +39,17 @@ class TanaNode(BaseModel):
     backlinks: List[str] = Field(default_factory=list)
     breadcrumbs: List[str] = Field(default_factory=list)
 
+    # Calendar and Temporal Provenance
+    effective_date: Optional[str] = None  # Format: YYYY-MM-DD
+    date_source: Optional[str] = None  # 'day_node', 'field', 'explicit_rel', 'fallback_created', 'none'
+    date_source_node_id: Optional[str] = None
+    calendar_distance: Optional[int] = None
+    calendar_path: Optional[str] = None
+    ancestor_day_node_id: Optional[str] = None
+    ancestor_week_node_id: Optional[str] = None
+    ancestor_month_node_id: Optional[str] = None
+    ancestor_year_node_id: Optional[str] = None
+
     @property
     def deep_link(self) -> str:
         return f"https://app.tana.inc/?nodeid={self.id}"

--- a/tana_context_mask/models/search.py
+++ b/tana_context_mask/models/search.py
@@ -8,6 +8,13 @@ class SemanticSearchRequest(BaseModel):
     scope_node_id: Optional[str] = None
     hybrid: bool = True
     alpha: float = 0.7  # 1.0 = pure vector, 0.0 = pure lexical
+    
+    # Temporal Parameters
+    target_date: Optional[str] = None  # Format: YYYY-MM-DD
+    date_from: Optional[str] = None  # Format: YYYY-MM-DD
+    date_to: Optional[str] = None  # Format: YYYY-MM-DD
+    temporal_mode: str = "none"  # "none", "boost", "filter", "strict"
+    temporal_weight: float = 0.40  # Weight for date proximity in 'boost' mode
 
 class SearchResultItem(BaseModel):
     id: str
@@ -20,9 +27,23 @@ class SearchResultItem(BaseModel):
     tags: List[str] = Field(default_factory=list)
     parent_id: Optional[str] = None
     last_updated: Optional[str] = None
+    
+    # Temporal Metadata & Provenance
+    effective_date: Optional[str] = None
+    date_source: Optional[str] = None
+    date_source_node_id: Optional[str] = None
+    calendar_path: Optional[str] = None
+    ancestor_day_node_id: Optional[str] = None
+    ancestor_month_node_id: Optional[str] = None
+    ancestor_year_node_id: Optional[str] = None
+    temporal_relationship: Optional[str] = None  # 'contemporaneous', 'retrospective', 'undated', 'conflicting'
+    temporal_score: Optional[float] = None
 
 class SearchResponse(BaseModel):
     query: str
     total_hits: int
     results: List[SearchResultItem]
     latency_ms: float
+    target_date: Optional[str] = None
+    temporal_mode: Optional[str] = None
+    insufficient_evidence: bool = False

--- a/tana_context_mask/storage/db.py
+++ b/tana_context_mask/storage/db.py
@@ -39,15 +39,45 @@ class SQLiteStore:
                     structure_hash TEXT,
                     is_done INTEGER DEFAULT 0,
                     in_trash INTEGER DEFAULT 0,
+                    effective_date TEXT,
+                    date_source TEXT,
+                    date_source_node_id TEXT,
+                    calendar_distance INTEGER,
+                    calendar_path TEXT,
+                    ancestor_day_node_id TEXT,
+                    ancestor_week_node_id TEXT,
+                    ancestor_month_node_id TEXT,
+                    ancestor_year_node_id TEXT,
                     raw_json TEXT
                 )
             """)
             
-            # Indexes on parent and status
+            # Migration check: add missing columns to existing database
+            table_info = conn.execute("PRAGMA table_info(nodes)").fetchall()
+            existing_cols = {col["name"] for col in table_info}
+            new_cols = [
+                ("effective_date", "TEXT"),
+                ("date_source", "TEXT"),
+                ("date_source_node_id", "TEXT"),
+                ("calendar_distance", "INTEGER"),
+                ("calendar_path", "TEXT"),
+                ("ancestor_day_node_id", "TEXT"),
+                ("ancestor_week_node_id", "TEXT"),
+                ("ancestor_month_node_id", "TEXT"),
+                ("ancestor_year_node_id", "TEXT")
+            ]
+            for col_name, col_type in new_cols:
+                if col_name not in existing_cols:
+                    conn.execute(f"ALTER TABLE nodes ADD COLUMN {col_name} {col_type}")
+
+            # Indexes on parent, status, and temporal fields
             conn.execute("CREATE INDEX IF NOT EXISTS idx_nodes_parent ON nodes(parent_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_nodes_doc_type ON nodes(doc_type)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_nodes_trash ON nodes(in_trash)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_nodes_updated ON nodes(updated_at)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_nodes_effective_date ON nodes(effective_date)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_nodes_ancestor_day ON nodes(ancestor_day_node_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_nodes_ancestor_year ON nodes(ancestor_year_node_id)")
 
             # Edges Table
             conn.execute("""
@@ -179,6 +209,15 @@ class SQLiteStore:
                 c_hash, s_hash,
                 1 if node.is_done else 0,
                 1 if node.in_trash else 0,
+                node.effective_date,
+                node.date_source,
+                node.date_source_node_id,
+                node.calendar_distance,
+                node.calendar_path,
+                node.ancestor_day_node_id,
+                node.ancestor_week_node_id,
+                node.ancestor_month_node_id,
+                node.ancestor_year_node_id,
                 None
             ))
 
@@ -209,8 +248,11 @@ class SQLiteStore:
                 INSERT INTO nodes (
                     id, name, description, doc_type, parent_id,
                     created_at, updated_at, content_hash, structure_hash,
-                    is_done, in_trash, raw_json
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    is_done, in_trash, effective_date, date_source,
+                    date_source_node_id, calendar_distance, calendar_path,
+                    ancestor_day_node_id, ancestor_week_node_id,
+                    ancestor_month_node_id, ancestor_year_node_id, raw_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     name = excluded.name,
                     description = excluded.description,
@@ -220,7 +262,16 @@ class SQLiteStore:
                     content_hash = excluded.content_hash,
                     structure_hash = excluded.structure_hash,
                     is_done = excluded.is_done,
-                    in_trash = excluded.in_trash
+                    in_trash = excluded.in_trash,
+                    effective_date = excluded.effective_date,
+                    date_source = excluded.date_source,
+                    date_source_node_id = excluded.date_source_node_id,
+                    calendar_distance = excluded.calendar_distance,
+                    calendar_path = excluded.calendar_path,
+                    ancestor_day_node_id = excluded.ancestor_day_node_id,
+                    ancestor_week_node_id = excluded.ancestor_week_node_id,
+                    ancestor_month_node_id = excluded.ancestor_month_node_id,
+                    ancestor_year_node_id = excluded.ancestor_year_node_id
             """, nodes_data)
 
             conn.executemany("DELETE FROM node_fts WHERE id = ?", fts_del_data)
@@ -323,9 +374,40 @@ class SQLiteStore:
                     children=list(dict.fromkeys(children_by_node.get(nid, []))),
                     references=list(dict.fromkeys(refs_by_node.get(nid, []))),
                     backlinks=list(dict.fromkeys(backlinks_by_node.get(nid, []))),
-                    breadcrumbs=breadcrumbs_memo[row["parent_id"]]
+                    breadcrumbs=breadcrumbs_memo[row["parent_id"]],
+                    effective_date=row["effective_date"] if "effective_date" in row.keys() else None,
+                    date_source=row["date_source"] if "date_source" in row.keys() else None,
+                    date_source_node_id=row["date_source_node_id"] if "date_source_node_id" in row.keys() else None,
+                    calendar_distance=row["calendar_distance"] if "calendar_distance" in row.keys() else None,
+                    calendar_path=row["calendar_path"] if "calendar_path" in row.keys() else None,
+                    ancestor_day_node_id=row["ancestor_day_node_id"] if "ancestor_day_node_id" in row.keys() else None,
+                    ancestor_week_node_id=row["ancestor_week_node_id"] if "ancestor_week_node_id" in row.keys() else None,
+                    ancestor_month_node_id=row["ancestor_month_node_id"] if "ancestor_month_node_id" in row.keys() else None,
+                    ancestor_year_node_id=row["ancestor_year_node_id"] if "ancestor_year_node_id" in row.keys() else None
                 ))
         return all_nodes
+
+    def get_nodes_by_date_range(self, date_from: str, date_to: str, limit: int = 200) -> List[TanaNode]:
+        with self.get_connection() as conn:
+            rows = conn.execute("""
+                SELECT * FROM nodes
+                WHERE in_trash = 0 AND effective_date IS NOT NULL
+                  AND effective_date >= ? AND effective_date <= ?
+                ORDER BY effective_date ASC
+                LIMIT ?
+            """, (date_from, date_to, limit)).fetchall()
+            return self._rows_to_nodes(conn, rows)
+
+    def get_day_nodes_in_range(self, date_from: str, date_to: str, limit: int = 100) -> List[TanaNode]:
+        with self.get_connection() as conn:
+            rows = conn.execute("""
+                SELECT * FROM nodes
+                WHERE in_trash = 0 AND date_source = 'day_node' AND calendar_distance = 0
+                  AND effective_date >= ? AND effective_date <= ?
+                ORDER BY effective_date ASC
+                LIMIT ?
+            """, (date_from, date_to, limit)).fetchall()
+            return self._rows_to_nodes(conn, rows)
 
     def _row_to_node(self, conn: sqlite3.Connection, row: sqlite3.Row) -> TanaNode:
         return self._rows_to_nodes(conn, [row])[0]

--- a/tana_context_mask/sync/mirror_engine.py
+++ b/tana_context_mask/sync/mirror_engine.py
@@ -9,6 +9,7 @@ from ..storage.db import SQLiteStore
 from ..storage.vector_store import VectorStore
 from ..client.tana_mcp_client import TanaMCPClient
 from ..models.node import TanaNode, NodeTag, NodeField
+from ..engine.temporal import resolve_node_provenance
 
 class MirrorEngine:
     def __init__(self, db: Optional[SQLiteStore] = None, vector_store: Optional[VectorStore] = None, client: Optional[TanaMCPClient] = None):
@@ -123,6 +124,20 @@ class MirrorEngine:
                 children=children,
                 updated_at=datetime.now().isoformat()
             )
+
+            # Resolve calendar provenance
+            parents = self.db.get_parents_chain(node_id, max_depth=8)
+            prov = resolve_node_provenance(node, parents)
+            node.effective_date = prov["effective_date"]
+            node.date_source = prov["date_source"]
+            node.date_source_node_id = prov["date_source_node_id"]
+            node.calendar_distance = prov["calendar_distance"]
+            node.calendar_path = prov["calendar_path"]
+            node.ancestor_day_node_id = prov["ancestor_day_node_id"]
+            node.ancestor_week_node_id = prov["ancestor_week_node_id"]
+            node.ancestor_month_node_id = prov["ancestor_month_node_id"]
+            node.ancestor_year_node_id = prov["ancestor_year_node_id"]
+
             updated_nodes.append(node)
             
             if name or desc:
@@ -242,7 +257,29 @@ class MirrorEngine:
             if max_nodes and count >= max_nodes:
                 break
 
-        print(f"Parsed {len(parsed_nodes)} valid user nodes. Ingesting into SQLite in batches...")
+        print(f"Parsed {len(parsed_nodes)} valid user nodes. Resolving calendar provenance...")
+        node_lookup = {n.id: n for n in parsed_nodes}
+        for node in parsed_nodes:
+            parents = []
+            curr_pid = node.parent_id
+            depth = 0
+            while curr_pid and curr_pid in node_lookup and depth < 8:
+                p_node = node_lookup[curr_pid]
+                parents.append(p_node)
+                curr_pid = p_node.parent_id
+                depth += 1
+            prov = resolve_node_provenance(node, parents)
+            node.effective_date = prov["effective_date"]
+            node.date_source = prov["date_source"]
+            node.date_source_node_id = prov["date_source_node_id"]
+            node.calendar_distance = prov["calendar_distance"]
+            node.calendar_path = prov["calendar_path"]
+            node.ancestor_day_node_id = prov["ancestor_day_node_id"]
+            node.ancestor_week_node_id = prov["ancestor_week_node_id"]
+            node.ancestor_month_node_id = prov["ancestor_month_node_id"]
+            node.ancestor_year_node_id = prov["ancestor_year_node_id"]
+
+        print(f"Ingesting into SQLite in batches...")
         
         # Batch insert into SQLite
         for i in range(0, len(parsed_nodes), batch_size):

--- a/tests/test_temporal_retrieval.py
+++ b/tests/test_temporal_retrieval.py
@@ -1,0 +1,262 @@
+import pytest
+import tempfile
+import os
+import shutil
+from datetime import date
+from tana_context_mask.storage.db import SQLiteStore
+from tana_context_mask.storage.vector_store import VectorStore
+from tana_context_mask.engine.semantic_search import SemanticSearchEngine
+from tana_context_mask.engine.context_builder import ContextBuilder
+from tana_context_mask.models.node import TanaNode, NodeTag, NodeField
+from tana_context_mask.models.search import SemanticSearchRequest
+from tana_context_mask.models.context import ContextAcquisitionRequest
+from tana_context_mask.engine.temporal import (
+    parse_iso_date,
+    is_day_node,
+    resolve_node_provenance,
+    compute_temporal_score,
+    classify_temporal_relationship,
+    parse_temporal_intent
+)
+
+@pytest.fixture
+def temporal_setup():
+    db_fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(db_fd)
+    vec_dir = tempfile.mkdtemp()
+    
+    db = SQLiteStore(db_path=db_path)
+    vector_store = VectorStore(db_path=vec_dir)
+    
+    # Create Day nodes and historical notes
+    # 1. 2019 Day node and contemporaneous note
+    day_2019 = TanaNode(
+        id="day_2019_09_01",
+        name="2019-09-01",
+        supertags=[NodeTag(tag_id="tag_day", tag_name="Day")],
+        effective_date="2019-09-01",
+        date_source="day_node",
+        date_source_node_id="day_2019_09_01"
+    )
+    note_2019 = TanaNode(
+        id="note_2019_physics",
+        name="Studying particle physics and quantum field theory",
+        description="Reading Griffiths chapter 4 on electrodynamics at the university library",
+        parent_id="day_2019_09_01",
+        effective_date="2019-09-01",
+        date_source="day_node",
+        date_source_node_id="day_2019_09_01",
+        ancestor_day_node_id="day_2019_09_01",
+        ancestor_year_node_id="2019"
+    )
+
+    # 2. 2026 Day node and retrospective note
+    day_2026 = TanaNode(
+        id="day_2026_09_01",
+        name="2026-09-01",
+        supertags=[NodeTag(tag_id="tag_day", tag_name="Day")],
+        effective_date="2026-09-01",
+        date_source="day_node",
+        date_source_node_id="day_2026_09_01"
+    )
+    note_2026_retro = TanaNode(
+        id="note_2026_reflection",
+        name="Reflecting on how my 2019 university physics years shaped my career",
+        description="Looking back at September 2019 studying quantum field theory and physics",
+        parent_id="day_2026_09_01",
+        effective_date="2026-09-01",
+        date_source="day_node",
+        date_source_node_id="day_2026_09_01",
+        ancestor_day_node_id="day_2026_09_01",
+        ancestor_year_node_id="2026"
+    )
+
+    # 3. Conflicting note: 2026 parent Day node, but explicit field says 2019-09-01
+    note_conflicting = TanaNode(
+        id="note_conflict",
+        name="Imported archive note about 2019 physics exam",
+        description="Physics exam notes from 2019",
+        parent_id="day_2026_09_01",
+        effective_date="2026-09-01",
+        date_source="day_node",
+        date_source_node_id="day_2026_09_01",
+        fields=[NodeField(field_id="f_date", field_name="Date", value_text="2019-09-01")]
+    )
+
+    all_nodes = [day_2019, note_2019, day_2026, note_2026_retro, note_conflicting]
+    db.bulk_upsert_nodes(all_nodes)
+
+    vector_store.upsert_vectors([
+        {"id": n.id, "name": n.name, "description": n.description, "hash": n.content_hash}
+        for n in all_nodes
+    ])
+
+    search_engine = SemanticSearchEngine(db=db, vector_store=vector_store)
+    context_builder = ContextBuilder(db=db, vector_store=vector_store, search_engine=search_engine)
+
+    yield db, vector_store, search_engine, context_builder
+
+    if os.path.exists(db_path):
+        os.remove(db_path)
+    if os.path.exists(vec_dir):
+        shutil.rmtree(vec_dir, ignore_errors=True)
+
+def test_day_node_date_extraction():
+    assert parse_iso_date("2019-09-01") == "2019-09-01"
+    assert parse_iso_date("September 1, 2019") == "2019-09-01"
+    assert parse_iso_date("1 Sep 2019") == "2019-09-01"
+    assert parse_iso_date("1st September 2019") == "2019-09-01"
+    assert parse_iso_date("Sun, Sep 1 2019") == "2019-09-01"
+
+    d_node = TanaNode(id="d1", name="September 1, 2019", supertags=[NodeTag(tag_id="t", tag_name="Day")])
+    is_day, d_str = is_day_node(d_node)
+    assert is_day is True
+    assert d_str == "2019-09-01"
+
+def test_nested_descendant_inheritance():
+    day_node = TanaNode(id="d_2019", name="2019-09-01", supertags=[NodeTag(tag_id="t", tag_name="Day")])
+    parent_section = TanaNode(id="sec_1", name="Morning Routine", parent_id="d_2019")
+    child_task = TanaNode(id="task_1", name="Review physics equations", parent_id="sec_1")
+
+    prov = resolve_node_provenance(child_task, [parent_section, day_node])
+    assert prov["effective_date"] == "2019-09-01"
+    assert prov["date_source"] == "day_node"
+    assert prov["date_source_node_id"] == "d_2019"
+    assert prov["calendar_distance"] == 2
+    assert prov["ancestor_year_node_id"] == "2019"
+
+def test_conflicting_provenance_detection():
+    day_node = TanaNode(id="d_2026", name="2026-09-01", supertags=[NodeTag(tag_id="t", tag_name="Day")])
+    conflict_node = TanaNode(
+        id="c1",
+        name="Imported archive entry",
+        parent_id="d_2026",
+        effective_date="2026-09-01",
+        date_source="day_node",
+        fields=[NodeField(field_id="f1", field_name="Date", value_text="2019-09-01")]
+    )
+    rel = classify_temporal_relationship(conflict_node, target_date_str="2019-09-01")
+    assert rel == "conflicting"
+
+def test_retrospective_classification():
+    retro_node = TanaNode(
+        id="r1",
+        name="Thinking about 2019 university days",
+        description="Looking back at September 2019",
+        effective_date="2026-09-01",
+        date_source="day_node"
+    )
+    rel = classify_temporal_relationship(retro_node, target_date_str="2019-09-01")
+    assert rel == "retrospective"
+
+def test_temporal_intent_parser():
+    intent = parse_temporal_intent("What was I doing this time in 2019?", reference_date=date(2026, 9, 1))
+    assert intent["has_temporal_intent"] is True
+    assert intent["target_date"] == "2019-09-01"
+    assert intent["temporal_mode"] == "strict"
+
+    intent_month = parse_temporal_intent("What happened in September 2018?")
+    assert intent_month["has_temporal_intent"] is True
+    assert intent_month["target_date"] == "2018-09-15"
+    assert intent_month["date_from"] == "2018-09-01"
+    assert intent_month["date_to"] == "2018-09-30"
+
+def test_historical_particle_physics_regression(temporal_setup):
+    """
+    Test 1: 2019 Day node note 'Studying particle physics' must outrank
+    2026 Day node note 'Reflecting on 2019 physics years' for the query:
+    'What was I doing this time in 2019?'
+    """
+    _, _, engine, _ = temporal_setup
+
+    req = SemanticSearchRequest(
+        query="What was I doing this time in 2019?",
+        target_date="2019-09-01",
+        temporal_mode="strict",
+        limit=5
+    )
+    resp = engine.search(req)
+
+    assert resp.total_hits >= 1
+    # Contemporaneous 2019 note must be the #1 result
+    assert resp.results[0].id == "note_2019_physics"
+    assert resp.results[0].temporal_relationship == "contemporaneous"
+    assert resp.results[0].effective_date == "2019-09-01"
+
+    # Retrospective 2026 note must NOT be present in strict results
+    result_ids = [r.id for r in resp.results]
+    assert "note_2026_reflection" not in result_ids
+    assert "note_conflict" not in result_ids
+
+def test_strict_temporal_gating_wrong_year_exclusion(temporal_setup):
+    """
+    Test 2: Wrong-year Day-node descendants must never pass strict historical retrieval.
+    """
+    _, _, engine, _ = temporal_setup
+
+    req = SemanticSearchRequest(
+        query="quantum field theory physics",
+        target_date="2019-09-01",
+        temporal_mode="strict",
+        limit=5
+    )
+    resp = engine.search(req)
+
+    result_ids = [r.id for r in resp.results]
+    assert "note_2019_physics" in result_ids
+    assert "note_2026_reflection" not in result_ids
+
+def test_boost_mode_scoring(temporal_setup):
+    """
+    Test 3: Boost mode allows cross-year results but boosts in-period notes.
+    """
+    _, _, engine, _ = temporal_setup
+
+    req = SemanticSearchRequest(
+        query="quantum field theory physics",
+        target_date="2019-09-01",
+        temporal_mode="boost",
+        limit=5
+    )
+    resp = engine.search(req)
+
+    assert resp.total_hits >= 2
+    # 2019 contemporaneous note is boosted above 2026 note
+    assert resp.results[0].id == "note_2019_physics"
+    assert resp.results[0].temporal_score >= 0.95
+
+def test_sparse_historical_data_insufficient_evidence(temporal_setup):
+    """
+    Test 4: Sparse historical data must return insufficient evidence rather than recent thematic matches.
+    """
+    _, _, engine, _ = temporal_setup
+
+    req = SemanticSearchRequest(
+        query="What was I doing this time in 2015?",
+        target_date="2015-09-01",
+        temporal_mode="strict",
+        limit=5
+    )
+    resp = engine.search(req)
+
+    assert resp.insufficient_evidence is True
+    assert len(resp.results) == 0
+
+def test_context_builder_packet_provenance(temporal_setup):
+    """
+    Test 5: Context builder outputs formatted markdown with contemporaneous badges.
+    """
+    _, _, _, context_builder = temporal_setup
+
+    req = ContextAcquisitionRequest(
+        task="What was I doing this time in 2019?",
+        target_date="2019-09-01",
+        temporal_mode="strict"
+    )
+    packet = context_builder.acquire_context(req)
+
+    assert len(packet.nodes) >= 1
+    assert packet.nodes[0].id == "note_2019_physics"
+    assert packet.nodes[0].temporal_relationship == "contemporaneous"
+    assert "Contemporaneous" in packet.formatted_context_markdown
+    assert "2019-09-01" in packet.formatted_context_markdown

--- a/worker/migration_002.sql
+++ b/worker/migration_002.sql
@@ -1,0 +1,13 @@
+ALTER TABLE nodes ADD COLUMN effective_date TEXT;
+ALTER TABLE nodes ADD COLUMN date_source TEXT;
+ALTER TABLE nodes ADD COLUMN date_source_node_id TEXT;
+ALTER TABLE nodes ADD COLUMN calendar_distance INTEGER;
+ALTER TABLE nodes ADD COLUMN calendar_path TEXT;
+ALTER TABLE nodes ADD COLUMN ancestor_day_node_id TEXT;
+ALTER TABLE nodes ADD COLUMN ancestor_week_node_id TEXT;
+ALTER TABLE nodes ADD COLUMN ancestor_month_node_id TEXT;
+ALTER TABLE nodes ADD COLUMN ancestor_year_node_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_nodes_effective_date ON nodes(effective_date);
+CREATE INDEX IF NOT EXISTS idx_nodes_ancestor_day ON nodes(ancestor_day_node_id);
+CREATE INDEX IF NOT EXISTS idx_nodes_ancestor_year ON nodes(ancestor_year_node_id);

--- a/worker/schema.sql
+++ b/worker/schema.sql
@@ -11,12 +11,24 @@ CREATE TABLE IF NOT EXISTS nodes (
     content_hash TEXT,
     structure_hash TEXT,
     is_done INTEGER DEFAULT 0,
-    in_trash INTEGER DEFAULT 0
+    in_trash INTEGER DEFAULT 0,
+    effective_date TEXT,
+    date_source TEXT,
+    date_source_node_id TEXT,
+    calendar_distance INTEGER,
+    calendar_path TEXT,
+    ancestor_day_node_id TEXT,
+    ancestor_week_node_id TEXT,
+    ancestor_month_node_id TEXT,
+    ancestor_year_node_id TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_nodes_parent ON nodes(parent_id);
 CREATE INDEX IF NOT EXISTS idx_nodes_trash ON nodes(in_trash);
 CREATE INDEX IF NOT EXISTS idx_nodes_updated ON nodes(updated_at);
+CREATE INDEX IF NOT EXISTS idx_nodes_effective_date ON nodes(effective_date);
+CREATE INDEX IF NOT EXISTS idx_nodes_ancestor_day ON nodes(ancestor_day_node_id);
+CREATE INDEX IF NOT EXISTS idx_nodes_ancestor_year ON nodes(ancestor_year_node_id);
 
 -- Full Text Search Index using SQLite FTS5
 CREATE VIRTUAL TABLE IF NOT EXISTS node_fts USING fts5(

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -210,12 +210,21 @@ app.get('/api/v1/health', async (c) => {
 });
 
 // Helper function for Context Acquisition
-async function handleAcquireContext(c: any, rawTask: string, rawQuery?: string, rawMaxNodes?: number) {
+async function handleAcquireContext(
+  c: any,
+  rawTask: string,
+  rawQuery?: string,
+  rawMaxNodes?: number,
+  rawTargetDate?: string,
+  rawTemporalMode?: string
+) {
   const startTime = Date.now();
   try {
     const task = (rawTask || '').trim();
     const query = (rawQuery || task).trim();
     const maxNodes = rawMaxNodes || 6;
+    const targetDate = rawTargetDate;
+    const temporalMode = rawTemporalMode || 'none';
     const traceId = crypto.randomUUID();
 
     if (!task && !query) {
@@ -226,10 +235,36 @@ async function handleAcquireContext(c: any, rawTask: string, rawQuery?: string, 
     const searchService = new HybridSearchService(c.env.DB, c.env.VECTORIZE, c.env.AI, graphStore);
     const reranker = new EdgeReranker();
 
-    // 1. Semantic + Keyword Search
-    const scoredSeeds = await searchService.searchWithScores(query, 20, 0.50);
-    const seedNodes = scoredSeeds.map(s => s.node);
-    const seedScoreMap = new Map<string, number>(scoredSeeds.map(s => [s.node.id, s.score]));
+    // 1. Semantic + Temporal Search
+    const searchResp = await searchService.searchWithTemporal({
+      query,
+      limit: 20,
+      target_date: targetDate,
+      temporal_mode: temporalMode as any
+    });
+
+    const seedNodes = searchResp.results.map(r => ({
+      id: r.id,
+      name: r.name,
+      description: r.description,
+      is_done: false,
+      in_trash: false,
+      supertags: r.tags.map(t => ({ tag_id: t, tag_name: t })),
+      fields: [],
+      children: [],
+      references: [],
+      backlinks: [],
+      breadcrumbs: r.breadcrumbs,
+      effective_date: r.effective_date,
+      date_source: r.date_source,
+      date_source_node_id: r.date_source_node_id,
+      calendar_path: r.calendar_path,
+      ancestor_day_node_id: r.ancestor_day_node_id,
+      ancestor_month_node_id: r.ancestor_month_node_id,
+      ancestor_year_node_id: r.ancestor_year_node_id
+    }));
+
+    const seedScoreMap = new Map<string, number>(searchResp.results.map(r => [r.id, r.score]));
 
     // 2. 1-Hop Graph Expansion
     const expandedPairs = await graphStore.expandSubgraph(seedNodes, 15);
@@ -241,7 +276,7 @@ async function handleAcquireContext(c: any, rawTask: string, rawQuery?: string, 
       reason: p.reason
     }));
 
-    const rankedCandidates = reranker.rerank(task, candidatePool, maxNodes);
+    const rankedCandidates = reranker.rerank(task, candidatePool, maxNodes, targetDate, undefined, undefined, temporalMode);
     const selectedNodes = rankedCandidates.map(r => r.node);
 
     // 4. Resolve Breadcrumbs and Child Snippets in parallel
@@ -256,7 +291,14 @@ async function handleAcquireContext(c: any, rawTask: string, rawQuery?: string, 
 
     mdSections.push(`### 🌐 Tana Context Mask: Retrieved Knowledge Graph`);
     mdSections.push(`> **Task:** ${task}`);
+    if (targetDate) {
+      mdSections.push(`> **Target Date:** \`${targetDate}\` | **Temporal Mode:** \`${temporalMode}\``);
+    }
     mdSections.push(`> **Trace ID:** \`${traceId}\` | **Nodes Selected:** ${rankedCandidates.length} of ${candidatePool.length} evaluated\n`);
+
+    if (searchResp.insufficient_evidence) {
+      mdSections.push(`> ⚠️ **Notice:** Insufficient contemporaneous evidence found in Tana for the requested historical period.\n`);
+    }
 
     for (let i = 0; i < rankedCandidates.length; i++) {
       const { node, score, reason } = rankedCandidates[i];
@@ -283,7 +325,9 @@ async function handleAcquireContext(c: any, rawTask: string, rawQuery?: string, 
         backlinks: node.backlinks || [],
         inclusion_reason: reason,
         relevance_score: score,
-        deep_link: deepLink
+        deep_link: deepLink,
+        effective_date: node.effective_date,
+        date_source: node.date_source
       });
 
       const itemLines = [
@@ -291,6 +335,10 @@ async function handleAcquireContext(c: any, rawTask: string, rawQuery?: string, 
         `- **Tana ID:** \`tana:${node.id}\` | **Relevance:** ${score.toFixed(2)}`,
         `- **Why included:** ${reason}`
       ];
+
+      if (node.effective_date) {
+        itemLines.push(`- **Calendar Provenance:** \`${node.effective_date}\` (source: \`${node.date_source || 'day_node'}\`)`);
+      }
 
       if (node.breadcrumbs && node.breadcrumbs.length > 0) {
         itemLines.push(`- **Hierarchy:** ${node.breadcrumbs.join(' > ')}`);
@@ -327,7 +375,10 @@ async function handleAcquireContext(c: any, rawTask: string, rawQuery?: string, 
       total_candidates_examined: candidatePool.length,
       graph_expansion_count: expandedPairs.length - seedNodes.length,
       latency_ms: latencyMs,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
+      target_date: targetDate,
+      temporal_mode: temporalMode,
+      insufficient_evidence: searchResp.insufficient_evidence
     };
 
     return c.json(packet);
@@ -348,29 +399,35 @@ app.post('/api/v1/context/acquire', async (c) => {
   const task = (body.task || body.query || body.prompt || body.q || body.input || body.message || c.req.query('task') || c.req.query('query') || c.req.query('q') || '').trim();
   const query = (body.query || body.q || task).trim();
   const maxNodes = body.max_nodes || parseInt(c.req.query('max_nodes') || '6', 10);
-  return handleAcquireContext(c, task, query, maxNodes);
+  const targetDate = body.target_date || c.req.query('target_date');
+  const temporalMode = body.temporal_mode || c.req.query('temporal_mode');
+  return handleAcquireContext(c, task, query, maxNodes, targetDate, temporalMode);
 });
 
 app.get('/api/v1/context/acquire', async (c) => {
   const task = (c.req.query('task') || c.req.query('query') || c.req.query('q') || c.req.query('prompt') || c.req.query('input') || '').trim();
   const query = (c.req.query('query') || c.req.query('q') || task).trim();
   const maxNodes = parseInt(c.req.query('max_nodes') || '6', 10);
-  return handleAcquireContext(c, task, query, maxNodes);
+  const targetDate = c.req.query('target_date');
+  const temporalMode = c.req.query('temporal_mode');
+  return handleAcquireContext(c, task, query, maxNodes, targetDate, temporalMode);
 });
 
 // Hybrid Search Endpoint (OpenAPI searchNodes - POST & GET)
 app.post('/api/v1/search', async (c) => {
   try {
-    let query = '';
-    let limit = 20;
+    let body: any = {};
     try {
-      const body = await c.req.json();
-      query = (body.query || body.q || body.task || '').trim();
-      limit = body.limit || 20;
-    } catch {
-      query = (c.req.query('query') || c.req.query('q') || c.req.query('task') || '').trim();
-      limit = parseInt(c.req.query('limit') || '20', 10);
-    }
+      body = await c.req.json();
+    } catch {}
+
+    const query = (body.query || body.q || body.task || c.req.query('query') || c.req.query('q') || '').trim();
+    const limit = body.limit || parseInt(c.req.query('limit') || '20', 10);
+    const tagFilter = body.tag_filter || c.req.query('tag_filter');
+    const targetDate = body.target_date || c.req.query('target_date');
+    const dateFrom = body.date_from || c.req.query('date_from');
+    const dateTo = body.date_to || c.req.query('date_to');
+    const temporalMode = body.temporal_mode || c.req.query('temporal_mode') || 'none';
 
     if (!query) {
       return c.json({ error: 'Query parameter required' }, 400);
@@ -378,17 +435,17 @@ app.post('/api/v1/search', async (c) => {
 
     const graphStore = new D1GraphStore(c.env.DB);
     const searchService = new HybridSearchService(c.env.DB, c.env.VECTORIZE, c.env.AI, graphStore);
-    const scoredNodes = await searchService.searchWithScores(query, limit);
+    const resp = await searchService.searchWithTemporal({
+      query,
+      limit,
+      tag_filter: tagFilter,
+      target_date: targetDate,
+      date_from: dateFrom,
+      date_to: dateTo,
+      temporal_mode: temporalMode
+    });
 
-    return c.json(scoredNodes.map(s => ({
-      id: s.node.id,
-      name: s.node.name,
-      description: s.node.description || '',
-      relevance_score: s.score,
-      supertags: s.node.supertags.map(t => t.tag_name),
-      breadcrumbs: s.node.breadcrumbs,
-      deep_link: s.node.deep_link
-    })));
+    return c.json(resp);
   } catch (err: any) {
     return c.json({ error: err.message }, 500);
   }
@@ -397,21 +454,27 @@ app.post('/api/v1/search', async (c) => {
 app.get('/api/v1/search', async (c) => {
   const query = (c.req.query('query') || c.req.query('q') || c.req.query('task') || '').trim();
   const limit = parseInt(c.req.query('limit') || '20', 10);
+  const tagFilter = c.req.query('tag_filter');
+  const targetDate = c.req.query('target_date');
+  const dateFrom = c.req.query('date_from');
+  const dateTo = c.req.query('date_to');
+  const temporalMode = (c.req.query('temporal_mode') || 'none') as any;
+
   if (!query) {
     return c.json({ error: 'Query parameter required' }, 400);
   }
   const graphStore = new D1GraphStore(c.env.DB);
   const searchService = new HybridSearchService(c.env.DB, c.env.VECTORIZE, c.env.AI, graphStore);
-  const scoredNodes = await searchService.searchWithScores(query, limit);
-  return c.json(scoredNodes.map(s => ({
-    id: s.node.id,
-    name: s.node.name,
-    description: s.node.description || '',
-    relevance_score: s.score,
-    supertags: s.node.supertags.map(t => t.tag_name),
-    breadcrumbs: s.node.breadcrumbs,
-    deep_link: s.node.deep_link
-  })));
+  const resp = await searchService.searchWithTemporal({
+    query,
+    limit,
+    tag_filter: tagFilter,
+    target_date: targetDate,
+    date_from: dateFrom,
+    date_to: dateTo,
+    temporal_mode: temporalMode
+  });
+  return c.json(resp);
 });
 
 // Single node inspection

--- a/worker/src/openapi.ts
+++ b/worker/src/openapi.ts
@@ -2,7 +2,7 @@ export const openApiSpec = {
   "openapi": "3.1.0",
   "info": {
     "title": "Tana Context Mask Plugin",
-    "description": "An embedding-backed, graph-aware semantic context acquisition plugin for Tana Outliner.",
+    "description": "An embedding-backed, graph-aware semantic context acquisition plugin for Tana Outliner with calendar-first temporal retrieval.",
     "version": "1.0.0"
   },
   "servers": [
@@ -76,6 +76,20 @@ export const openApiSpec = {
             "required": false,
             "schema": { "type": "integer", "default": 6 },
             "description": "Maximum nodes to retrieve"
+          },
+          {
+            "name": "target_date",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" },
+            "description": "Target date (YYYY-MM-DD) for historical retrieval"
+          },
+          {
+            "name": "temporal_mode",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "enum": ["none", "boost", "filter", "strict"], "default": "none" },
+            "description": "Temporal gating mode"
           }
         ],
         "responses": {
@@ -95,7 +109,7 @@ export const openApiSpec = {
     "/api/v1/search": {
       "post": {
         "summary": "Hybrid Search (POST)",
-        "description": "Direct hybrid semantic and keyword search across Tana corpus.",
+        "description": "Direct hybrid semantic and keyword search across Tana corpus with calendar provenance and temporal gating.",
         "operationId": "searchNodes",
         "requestBody": {
           "required": true,
@@ -105,7 +119,12 @@ export const openApiSpec = {
                 "type": "object",
                 "properties": {
                   "query": { "type": "string" },
-                  "limit": { "type": "integer", "default": 20 }
+                  "limit": { "type": "integer", "default": 20 },
+                  "tag_filter": { "type": "string" },
+                  "target_date": { "type": "string" },
+                  "date_from": { "type": "string" },
+                  "date_to": { "type": "string" },
+                  "temporal_mode": { "type": "string", "enum": ["none", "boost", "filter", "strict"], "default": "none" }
                 },
                 "required": ["query"]
               }
@@ -132,6 +151,18 @@ export const openApiSpec = {
             "in": "query",
             "required": false,
             "schema": { "type": "integer", "default": 20 }
+          },
+          {
+            "name": "target_date",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "temporal_mode",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "enum": ["none", "boost", "filter", "strict"], "default": "none" }
           }
         ],
         "responses": {
@@ -177,7 +208,11 @@ export const openApiSpec = {
           "query": { "type": "string", "description": "Optional refined search query" },
           "scope": { "type": "string", "description": "Optional supertag scope filter" },
           "max_nodes": { "type": "integer", "default": 6, "description": "Maximum number of context nodes" },
-          "include_children": { "type": "boolean", "default": true, "description": "Whether to resolve child bullets" }
+          "include_children": { "type": "boolean", "default": true, "description": "Whether to resolve child bullets" },
+          "target_date": { "type": "string", "description": "Optional target date (YYYY-MM-DD)" },
+          "date_from": { "type": "string", "description": "Optional start date" },
+          "date_to": { "type": "string", "description": "Optional end date" },
+          "temporal_mode": { "type": "string", "enum": ["none", "boost", "filter", "strict"], "default": "none" }
         },
         "required": ["task"]
       },
@@ -193,7 +228,10 @@ export const openApiSpec = {
           "children_snippets": { "type": "array", "items": { "type": "string" } },
           "inclusion_reason": { "type": "string" },
           "relevance_score": { "type": "number" },
-          "deep_link": { "type": "string" }
+          "deep_link": { "type": "string" },
+          "effective_date": { "type": "string" },
+          "date_source": { "type": "string" },
+          "temporal_relationship": { "type": "string" }
         },
         "required": ["id", "name", "deep_link"]
       },
@@ -208,7 +246,10 @@ export const openApiSpec = {
           "total_candidates_examined": { "type": "integer" },
           "graph_expansion_count": { "type": "integer" },
           "latency_ms": { "type": "number" },
-          "timestamp": { "type": "string" }
+          "timestamp": { "type": "string" },
+          "target_date": { "type": "string" },
+          "temporal_mode": { "type": "string" },
+          "insufficient_evidence": { "type": "boolean" }
         },
         "required": ["trace_id", "task", "summary", "formatted_context_markdown", "nodes"]
       }

--- a/worker/src/services/mcp.ts
+++ b/worker/src/services/mcp.ts
@@ -3,6 +3,7 @@ import { D1GraphStore } from './graph';
 import { HybridSearchService } from './search';
 import { EdgeReranker } from './reranker';
 import { EdgeSyncService } from './sync';
+import { classifyTemporalRelationship } from './temporal';
 
 export interface JSONRPCRequest {
   jsonrpc: string;
@@ -62,19 +63,26 @@ export class RemoteMCPHandler {
                   task: { type: 'string', description: 'The user prompt, task, or question' },
                   query: { type: 'string', description: 'Optional refined search query' },
                   scope: { type: 'string', description: 'Optional supertag scope filter' },
-                  max_nodes: { type: 'integer', default: 6, description: 'Maximum number of context nodes' }
+                  max_nodes: { type: 'integer', default: 6, description: 'Maximum number of context nodes' },
+                  target_date: { type: 'string', description: 'Optional target date (YYYY-MM-DD) for historical context' },
+                  temporal_mode: { type: 'string', enum: ['none', 'boost', 'filter', 'strict'], description: 'Temporal gating mode' }
                 },
                 required: ['task']
               }
             },
             {
               name: 'search_nodes',
-              description: 'Direct hybrid semantic and keyword search across Tana corpus.',
+              description: 'Direct hybrid semantic and keyword search across Tana corpus with calendar provenance and temporal gating.',
               inputSchema: {
                 type: 'object',
                 properties: {
                   query: { type: 'string', description: 'Search query' },
-                  limit: { type: 'integer', default: 20, description: 'Max results' }
+                  limit: { type: 'integer', default: 20, description: 'Max results' },
+                  tag_filter: { type: 'string', description: 'Optional tag filter' },
+                  target_date: { type: 'string', description: 'Optional target date (YYYY-MM-DD)' },
+                  date_from: { type: 'string', description: 'Optional start date' },
+                  date_to: { type: 'string', description: 'Optional end date' },
+                  temporal_mode: { type: 'string', enum: ['none', 'boost', 'filter', 'strict'], description: 'Temporal gating mode' }
                 },
                 required: ['query']
               }
@@ -115,17 +123,45 @@ export class RemoteMCPHandler {
         const task = (toolArgs.task || '').trim();
         const query = (toolArgs.query || task).trim();
         const maxNodes = toolArgs.max_nodes || 6;
+        const targetDate = toolArgs.target_date;
+        const temporalMode = toolArgs.temporal_mode || 'none';
 
-        const scoredSeeds = await searchService.searchWithScores(query, 20, 0.50);
-        const seedNodes = scoredSeeds.map(s => s.node);
-        const seedScoreMap = new Map<string, number>(scoredSeeds.map(s => [s.node.id, s.score]));
+        const searchResp = await searchService.searchWithTemporal({
+          query,
+          limit: 20,
+          target_date: targetDate,
+          temporal_mode: temporalMode
+        });
+
+        const seedNodes = searchResp.results.map(r => ({
+          id: r.id,
+          name: r.name,
+          description: r.description,
+          is_done: false,
+          in_trash: false,
+          supertags: r.tags.map(t => ({ tag_id: t, tag_name: t })),
+          fields: [],
+          children: [],
+          references: [],
+          backlinks: [],
+          breadcrumbs: r.breadcrumbs,
+          effective_date: r.effective_date,
+          date_source: r.date_source,
+          date_source_node_id: r.date_source_node_id,
+          calendar_path: r.calendar_path,
+          ancestor_day_node_id: r.ancestor_day_node_id,
+          ancestor_month_node_id: r.ancestor_month_node_id,
+          ancestor_year_node_id: r.ancestor_year_node_id
+        }));
+
+        const seedScoreMap = new Map<string, number>(searchResp.results.map(r => [r.id, r.score]));
         const expandedPairs = await graphStore.expandSubgraph(seedNodes, 15);
         const candidatePool = expandedPairs.map(p => ({
           node: p.node,
           score: seedScoreMap.has(p.node.id) ? seedScoreMap.get(p.node.id)! : 0.45,
           reason: p.reason
         }));
-        const rankedCandidates = reranker.rerank(task, candidatePool, maxNodes);
+        const rankedCandidates = reranker.rerank(task, candidatePool, maxNodes, targetDate, undefined, undefined, temporalMode);
         const selectedNodes = rankedCandidates.map(r => r.node);
 
         const [_, childrenSnippetsMap] = await Promise.all([
@@ -135,7 +171,15 @@ export class RemoteMCPHandler {
 
         const mdSections: string[] = [];
         mdSections.push(`### 🌐 Tana Context Mask: Retrieved Knowledge Graph`);
-        mdSections.push(`> **Task:** ${task}\n`);
+        mdSections.push(`> **Task:** ${task}`);
+        if (targetDate) {
+          mdSections.push(`> **Target Date:** \`${targetDate}\` | **Temporal Mode:** \`${temporalMode}\``);
+        }
+        mdSections.push('');
+
+        if (searchResp.insufficient_evidence) {
+          mdSections.push(`> ⚠️ **Notice:** Insufficient contemporaneous evidence found in Tana for the requested period.\n`);
+        }
 
         for (let i = 0; i < rankedCandidates.length; i++) {
           const { node, score, reason } = rankedCandidates[i];
@@ -143,11 +187,23 @@ export class RemoteMCPHandler {
           const deepLink = node.deep_link || `https://app.tana.inc/?nodeid=${node.id}`;
           const snippets = childrenSnippetsMap.get(node.id) || [];
 
+          const relClass = classifyTemporalRelationship(node, targetDate);
+          let relBadge = '';
+          if (relClass === 'contemporaneous') {
+            relBadge = ` \`[Contemporaneous · ${node.effective_date || 'verified'}]\``;
+          } else if (relClass === 'retrospective') {
+            relBadge = ` \`[Retrospective · recorded ${node.effective_date || 'later'}]\``;
+          }
+
           const itemLines = [
-            `#### ${i + 1}. [${node.name}](${deepLink}) ${tagsBadge}`,
+            `#### ${i + 1}. [${node.name}](${deepLink}) ${tagsBadge}${relBadge}`,
             `- **Tana ID:** \`tana:${node.id}\` | **Relevance:** ${score.toFixed(2)}`,
             `- **Why included:** ${reason}`
           ];
+
+          if (node.effective_date) {
+            itemLines.push(`- **Calendar Provenance:** \`${node.effective_date}\` (source: \`${node.date_source || 'day_node'}\`)`);
+          }
 
           if (node.breadcrumbs && node.breadcrumbs.length > 0) {
             itemLines.push(`- **Hierarchy:** ${node.breadcrumbs.join(' > ')}`);
@@ -184,7 +240,20 @@ export class RemoteMCPHandler {
       if (toolName === 'search_nodes') {
         const query = (toolArgs.query || '').trim();
         const limit = toolArgs.limit || 20;
-        const results = await searchService.search(query, limit);
+        const targetDate = toolArgs.target_date;
+        const dateFrom = toolArgs.date_from;
+        const dateTo = toolArgs.date_to;
+        const temporalMode = toolArgs.temporal_mode || 'none';
+
+        const resp = await searchService.searchWithTemporal({
+          query,
+          limit,
+          tag_filter: toolArgs.tag_filter,
+          target_date: targetDate,
+          date_from: dateFrom,
+          date_to: dateTo,
+          temporal_mode: temporalMode
+        });
 
         return {
           jsonrpc: '2.0',
@@ -193,13 +262,7 @@ export class RemoteMCPHandler {
             content: [
               {
                 type: 'text',
-                text: JSON.stringify(results.map(n => ({
-                  id: n.id,
-                  name: n.name,
-                  description: n.description,
-                  deep_link: n.deep_link,
-                  tags: n.supertags.map(t => t.tag_name)
-                })), null, 2)
+                text: JSON.stringify(resp, null, 2)
               }
             ]
           }

--- a/worker/src/services/reranker.ts
+++ b/worker/src/services/reranker.ts
@@ -1,12 +1,22 @@
 import { TanaNode, ScoredCandidate } from '../types';
+import { computeTemporalScore, classifyTemporalRelationship, isDayNode } from './temporal';
 
 export class EdgeReranker {
   /**
-   * Multi-factor reranking based on semantic score, freshness, structural depth, and deduplication.
+   * Multi-factor reranking based on semantic score, temporal proximity/provenance, structural depth, and deduplication.
    */
-  rerank(task: string, candidates: Array<{ node: TanaNode; score: number; reason: string }>, maxNodes: number = 8): ScoredCandidate[] {
+  rerank(
+    task: string,
+    candidates: Array<{ node: TanaNode; score: number; reason: string }>,
+    maxNodes: number = 8,
+    targetDate?: string,
+    dateFrom?: string,
+    dateTo?: string,
+    temporalMode: string = 'none'
+  ): ScoredCandidate[] {
     const taskTokens = new Set((task.toLowerCase().match(/\w+/g) || []).filter(t => t.length > 2));
     const now = Date.now();
+    const targetYear = targetDate ? targetDate.substring(0, 4) : (dateFrom ? dateFrom.substring(0, 4) : undefined);
 
     const scored: ScoredCandidate[] = [];
 
@@ -14,12 +24,12 @@ export class EdgeReranker {
       let finalScore = c.score;
       const cleanName = c.node.name.trim();
 
-      // Penalize placeholder/empty template titles (e.g. "Title:", "Untitled") unless they have substantive descriptions
+      // Penalize placeholder/empty template titles
       if ((cleanName.toLowerCase() === 'title:' || cleanName.toLowerCase() === 'untitled' || cleanName.length < 3) && (!c.node.description || c.node.description.length < 10)) {
         finalScore -= 0.35;
       }
 
-      // 1. Exact Lexical Overlap Boost (Node Name & Description)
+      // 1. Exact Lexical Overlap Boost
       const nameAndDesc = `${cleanName} ${c.node.description || ''}`.toLowerCase();
       const nodeTokens = new Set((nameAndDesc.match(/\w+/g) || []));
       let nameOverlapCount = 0;
@@ -32,7 +42,6 @@ export class EdgeReranker {
       }
 
       // 2. High-Priority Field Name & Value Scoring
-      // Fields define the core semantics and properties of typed nodes in Tana
       let fieldMatchCount = 0;
       const matchedFieldDetails: string[] = [];
       const hasFields = c.node.fields && c.node.fields.length > 0;
@@ -54,31 +63,54 @@ export class EdgeReranker {
           }
         }
 
-        // Field semantic relevance boost (up to +0.30)
         if (taskTokens.size > 0 && fieldMatchCount > 0) {
           finalScore += Math.min(0.30, (fieldMatchCount / taskTokens.size) * 0.35);
         }
-
-        // Schema Density Bonus: Typed nodes with populated fields get higher prominence over loose bullets
         finalScore += Math.min(0.08, c.node.fields.length * 0.02);
       }
 
-      // 3. Freshness Boost (recent updates within last 30 days get small bump)
-      if (c.node.updated_at) {
-        try {
-          const updatedTime = new Date(c.node.updated_at).getTime();
-          const ageDays = (now - updatedTime) / (1000 * 60 * 60 * 24);
-          if (ageDays < 30) {
-            finalScore += 0.05 * (1.0 - ageDays / 30);
+      // 3. Temporal Handling
+      if (targetDate || ['strict', 'boost', 'filter'].includes(temporalMode)) {
+        const tempScore = computeTemporalScore(c.node.effective_date, targetDate, dateFrom, dateTo);
+        const relClass = classifyTemporalRelationship(c.node, targetDate, targetYear);
+
+        if (temporalMode === 'strict') {
+          if (relClass === 'contemporaneous') {
+            finalScore += 0.30 + (tempScore * 0.20);
+          } else if (relClass === 'retrospective') {
+            finalScore -= 0.50;
+          } else if (relClass === 'conflicting') {
+            finalScore -= 0.60;
+          } else {
+            finalScore -= 0.40;
           }
-        } catch {
-          // Ignore parse errors
+        } else if (temporalMode === 'boost') {
+          finalScore = (finalScore * 0.60) + (tempScore * 0.40);
+        }
+      } else {
+        // General query recency boost
+        if (c.node.updated_at) {
+          try {
+            const updatedTime = new Date(c.node.updated_at).getTime();
+            const ageDays = (now - updatedTime) / (1000 * 60 * 60 * 24);
+            if (ageDays < 30) {
+              finalScore += 0.05 * (1.0 - ageDays / 30);
+            }
+          } catch {
+            // Ignore parse errors
+          }
         }
       }
 
       // 4. Supertag relevance
       if (c.node.supertags && c.node.supertags.length > 0) {
         finalScore += 0.05;
+      }
+
+      // 5. Bare calendar container demotion
+      const [isBareCal] = isDayNode(c.node);
+      if (isBareCal && !c.node.description && !hasFields) {
+        finalScore *= 0.40;
       }
 
       let annotatedReason = c.reason;
@@ -98,7 +130,7 @@ export class EdgeReranker {
     // Sort descending by score
     scored.sort((a, b) => b.score - a.score);
 
-    // Context deduplication: prune exact identical name duplicates IF they share the same parent
+    // Context deduplication
     const seenSignatures = new Set<string>();
     const deduplicated: ScoredCandidate[] = [];
 

--- a/worker/src/services/search.ts
+++ b/worker/src/services/search.ts
@@ -1,6 +1,12 @@
 import { D1Database, VectorizeIndex, Ai } from '@cloudflare/workers-types';
-import { TanaNode } from '../types';
+import { TanaNode, SemanticSearchRequest, SearchResponse, SearchResultItem } from '../types';
 import { D1GraphStore } from './graph';
+import {
+  computeTemporalScore,
+  classifyTemporalRelationship,
+  parseTemporalIntent,
+  isDayNode
+} from './temporal';
 
 export interface SearchHit {
   id: string;
@@ -43,23 +49,75 @@ export class HybridSearchService {
     const response: any = await this.ai.run('@cf/baai/bge-small-en-v1.5', {
       text: [query]
     });
-    // Cloudflare Workers AI returns { shape: [...], data: [[...]] }
     if (response && response.data && response.data[0]) {
       return response.data[0];
     }
     throw new Error('Failed to generate embedding from Workers AI');
   }
 
+  async getNodesByDateRange(dateFrom: string, dateTo: string, limit: number = 100): Promise<TanaNode[]> {
+    const { results } = await this.db
+      .prepare(`
+        SELECT id FROM nodes
+        WHERE in_trash = 0 AND effective_date IS NOT NULL
+          AND effective_date >= ? AND effective_date <= ?
+        ORDER BY effective_date ASC
+        LIMIT ?
+      `)
+      .bind(dateFrom, dateTo, limit)
+      .all<any>();
+    const ids = (results || []).map(r => r.id);
+    return this.graphStore.getNodesByIds(ids);
+  }
+
   /**
-   * Performs hybrid search returning nodes with their calibrated fusion score.
+   * Performs hybrid search with full calendar provenance & temporal gating.
    */
-  async searchWithScores(query: string, limit: number = 20, alpha: number = 0.50): Promise<ScoredNode[]> {
-    // 1. Vector Search via Vectorize
+  async searchWithTemporal(req: SemanticSearchRequest): Promise<SearchResponse> {
+    const startT = Date.now();
+    const query = (req.query || '').trim();
+    if (!query) {
+      return { query, total_hits: 0, results: [], latency_ms: 0 };
+    }
+
+    const limit = req.limit || 20;
+    const alpha = 0.50;
+    let targetDate = req.target_date;
+    let dateFrom = req.date_from;
+    let dateTo = req.date_to;
+    let temporalMode = req.temporal_mode || 'none';
+    const temporalWeight = req.temporal_weight || 0.40;
+
+    if (temporalMode === 'none' && !targetDate && !dateFrom && !dateTo) {
+      const intent = parseTemporalIntent(query);
+      if (intent.has_temporal_intent && intent.target_date) {
+        targetDate = intent.target_date;
+        dateFrom = intent.date_from;
+        dateTo = intent.date_to;
+        temporalMode = intent.temporal_mode;
+      }
+    }
+
+    const candidateMap = new Map<string, TanaNode>();
+    const vectorScores = new Map<string, number>();
+    const keywordScores = new Map<string, number>();
+
+    // Strategy A: Calendar-first candidate generation for strict/filter
+    if (['strict', 'filter'].includes(temporalMode) && (targetDate || dateFrom || dateTo)) {
+      const wFrom = dateFrom || (targetDate ? `${targetDate.slice(0, 7)}-01` : '1900-01-01');
+      const wTo = dateTo || (targetDate ? `${targetDate.slice(0, 7)}-31` : '2099-12-31');
+      const calNodes = await this.getNodesByDateRange(wFrom, wTo, 100);
+      for (const cn of calNodes) {
+        candidateMap.set(cn.id, cn);
+      }
+    }
+
+    // Strategy B: Vector + Lexical Search
     const vectorPromise = (async () => {
       try {
         const queryVector = await this.embedQuery(query);
         const vectorResults = await this.vectorize.query(queryVector, {
-          topK: limit * 2,
+          topK: limit * 3,
           returnValues: false,
           returnMetadata: 'none'
         });
@@ -70,7 +128,6 @@ export class HybridSearchService {
       }
     })();
 
-    // 2. Keyword Search via D1 FTS5 (with stopword filtering and phrase matching)
     const keywordPromise = (async () => {
       try {
         const rawTokens = (query.toLowerCase().match(/\w+/g) || []);
@@ -78,8 +135,6 @@ export class HybridSearchService {
         const searchTerms = meaningfulTerms.length > 0 ? meaningfulTerms : rawTokens.filter(t => t.length > 1);
 
         if (searchTerms.length === 0) return [];
-        
-        // Exact phrase prefix + individual token prefix OR
         const phraseTerm = `"${searchTerms.join(' ')}"`;
         const ftsQuery = [phraseTerm, ...searchTerms.map(t => `"${t}"*`)].join(' OR ');
 
@@ -92,11 +147,10 @@ export class HybridSearchService {
             ORDER BY rank_score ASC
             LIMIT ?
           `)
-          .bind(ftsQuery, limit * 2)
+          .bind(ftsQuery, limit * 3)
           .all<any>();
 
         return (results || []).map((r: any, idx: number) => {
-          // Top keyword match receives 1.0, 2nd receives 0.96, etc.
           const keywordScore = Math.max(0.4, 1.0 - (idx * 0.04));
           return { id: r.id, score: keywordScore };
         });
@@ -108,42 +162,160 @@ export class HybridSearchService {
 
     const [vectorHits, keywordHits] = await Promise.all([vectorPromise, keywordPromise]);
 
-    // 3. Score Fusion (Alpha Weighted)
-    const fusedScores = new Map<string, number>();
-
     for (const v of vectorHits) {
-      fusedScores.set(v.id, (fusedScores.get(v.id) || 0) + v.score * alpha);
+      vectorScores.set(v.id, v.score);
     }
-
     for (const k of keywordHits) {
-      fusedScores.set(k.id, (fusedScores.get(k.id) || 0) + k.score * (1.0 - alpha));
+      keywordScores.set(k.id, k.score);
     }
 
-    // Sort by final score
-    const sortedEntries = Array.from(fusedScores.entries())
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, limit);
+    const allCandidateIds = new Set<string>([
+      ...Array.from(candidateMap.keys()),
+      ...Array.from(vectorScores.keys()),
+      ...Array.from(keywordScores.keys())
+    ]);
 
-    const rankedIds = sortedEntries.map(e => e[0]);
-    const nodes = await this.graphStore.getNodesByIds(rankedIds);
-    const nodeMap = new Map<string, TanaNode>(nodes.map(n => [n.id, n]));
-
-    const scoredNodes: ScoredNode[] = [];
-    for (const [id, score] of sortedEntries) {
-      const node = nodeMap.get(id);
-      if (node) {
-        scoredNodes.push({ node, score });
+    const missingIds = Array.from(allCandidateIds).filter(id => !candidateMap.has(id));
+    if (missingIds.length > 0) {
+      const hydrated = await this.graphStore.getNodesByIds(missingIds);
+      for (const h of hydrated) {
+        candidateMap.set(h.id, h);
       }
     }
 
-    return scoredNodes;
+    const targetYear = targetDate ? targetDate.substring(0, 4) : (dateFrom ? dateFrom.substring(0, 4) : undefined);
+    const scoredList: Array<{
+      node: TanaNode;
+      finalScore: number;
+      semScore: number;
+      lexScore: number;
+      tempScore: number;
+      relClass: string;
+    }> = [];
+
+    for (const [id, node] of candidateMap.entries()) {
+      if (node.in_trash) continue;
+
+      if (req.tag_filter) {
+        const tagNames = (node.supertags || []).map(t => t.tag_name.toLowerCase());
+        if (!tagNames.some(tn => tn.includes(req.tag_filter!.toLowerCase()))) {
+          continue;
+        }
+      }
+
+      const sScore = vectorScores.get(id) || 0.0;
+      const lScore = keywordScores.get(id) || 0.0;
+      const baseScore = (alpha * sScore) + ((1.0 - alpha) * lScore);
+
+      const tempScore = computeTemporalScore(node.effective_date, targetDate, dateFrom, dateTo);
+      const relClass = classifyTemporalRelationship(node, targetDate, targetYear);
+
+      let finalScore = baseScore;
+
+      if (temporalMode === 'none') {
+        finalScore = baseScore;
+      } else if (temporalMode === 'boost') {
+        finalScore = ((1.0 - temporalWeight) * baseScore) + (temporalWeight * tempScore);
+      } else if (temporalMode === 'filter') {
+        if (!node.effective_date || tempScore <= 0.0) continue;
+        if (dateFrom && node.effective_date < dateFrom) continue;
+        if (dateTo && node.effective_date > dateTo) continue;
+        finalScore = baseScore;
+      } else if (temporalMode === 'strict') {
+        if (!node.effective_date || !['day_node', 'field', 'explicit_rel'].includes(node.date_source || '')) {
+          continue;
+        }
+        if (relClass === 'conflicting' || relClass === 'retrospective') {
+          continue;
+        }
+        if (targetYear && node.effective_date.substring(0, 4) !== targetYear) {
+          continue;
+        }
+        if (dateFrom && node.effective_date < dateFrom) continue;
+        if (dateTo && node.effective_date > dateTo) continue;
+        finalScore = (baseScore * 0.70) + (tempScore * 0.30);
+      }
+
+      const [isBareCal] = isDayNode(node);
+      if (isBareCal && !node.description && (!node.fields || node.fields.length === 0)) {
+        finalScore *= 0.50;
+      } else if (node.description || (node.fields && node.fields.length > 0)) {
+        finalScore += 0.05;
+      }
+
+      scoredList.push({
+        node,
+        finalScore,
+        semScore: sScore,
+        lexScore: lScore,
+        tempScore,
+        relClass
+      });
+    }
+
+    scoredList.sort((a, b) => b.finalScore - a.finalScore);
+    const top = scoredList.slice(0, limit);
+
+    const results: SearchResultItem[] = top.map(item => ({
+      id: item.node.id,
+      name: item.node.name,
+      description: item.node.description || '',
+      score: Math.round(item.finalScore * 10000) / 10000,
+      semantic_score: Math.round(item.semScore * 10000) / 10000,
+      lexical_score: Math.round(item.lexScore * 10000) / 10000,
+      breadcrumbs: item.node.breadcrumbs || [],
+      tags: (item.node.supertags || []).map(t => t.tag_name),
+      parent_id: item.node.parent_id,
+      last_updated: item.node.updated_at,
+      effective_date: item.node.effective_date,
+      date_source: item.node.date_source,
+      date_source_node_id: item.node.date_source_node_id,
+      calendar_path: item.node.calendar_path,
+      ancestor_day_node_id: item.node.ancestor_day_node_id,
+      ancestor_month_node_id: item.node.ancestor_month_node_id,
+      ancestor_year_node_id: item.node.ancestor_year_node_id,
+      temporal_relationship: item.relClass,
+      temporal_score: Math.round(item.tempScore * 10000) / 10000
+    }));
+
+    const latencyMs = Date.now() - startT;
+    const insufficient = results.length === 0 && temporalMode === 'strict' && targetDate !== undefined;
+
+    return {
+      query,
+      total_hits: results.length,
+      results,
+      latency_ms: latencyMs,
+      target_date: targetDate,
+      temporal_mode: temporalMode,
+      insufficient_evidence: insufficient
+    };
   }
 
   /**
-   * Performs hybrid search across Cloudflare Vectorize and D1 FTS5.
+   * Performs hybrid search returning nodes.
    */
   async search(query: string, limit: number = 20, alpha: number = 0.50): Promise<TanaNode[]> {
-    const scored = await this.searchWithScores(query, limit, alpha);
-    return scored.map(s => s.node);
+    const res = await this.searchWithTemporal({ query, limit });
+    return res.results.map(r => ({
+      id: r.id,
+      name: r.name,
+      description: r.description,
+      is_done: false,
+      in_trash: false,
+      supertags: r.tags.map(t => ({ tag_id: t, tag_name: t })),
+      fields: [],
+      children: [],
+      references: [],
+      backlinks: [],
+      breadcrumbs: r.breadcrumbs,
+      effective_date: r.effective_date,
+      date_source: r.date_source,
+      date_source_node_id: r.date_source_node_id,
+      calendar_path: r.calendar_path,
+      ancestor_day_node_id: r.ancestor_day_node_id,
+      ancestor_month_node_id: r.ancestor_month_node_id,
+      ancestor_year_node_id: r.ancestor_year_node_id
+    }));
   }
 }

--- a/worker/src/services/sync.ts
+++ b/worker/src/services/sync.ts
@@ -20,9 +20,9 @@ export class EdgeSyncService {
   ) {}
 
   /**
-   * Helper to call Tana Remote MCP JSON-RPC 2.0 tool endpoint.
+   * Helper to call Tana Remote MCP JSON-RPC 2.0 tool endpoint with retry & backoff.
    */
-  private async callTanaMCP(toolName: string, args: Record<string, any>): Promise<any> {
+  private async callTanaMCP(toolName: string, args: Record<string, any>, maxRetries: number = 3): Promise<any> {
     if (!this.tanaToken) return null;
 
     const payload = {
@@ -35,37 +35,57 @@ export class EdgeSyncService {
       id: 1
     };
 
-    const res = await fetch('https://app.tana.inc/mcp', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${this.tanaToken}`,
-        'Content-Type': 'application/json',
-        'Accept': 'application/json, text/event-stream'
-      },
-      body: JSON.stringify(payload)
-    });
+    let attempt = 0;
+    while (attempt < maxRetries) {
+      attempt++;
+      try {
+        const res = await fetch('https://app.tana.inc/mcp', {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${this.tanaToken}`,
+            'Content-Type': 'application/json',
+            'Accept': 'application/json, text/event-stream'
+          },
+          body: JSON.stringify(payload)
+        });
 
-    if (!res.ok) {
-      throw new Error(`Tana MCP responded with HTTP ${res.status}`);
-    }
-
-    const jsonRpcRes: any = await res.json();
-    if (jsonRpcRes.error) {
-      throw new Error(`Tana MCP error: ${jsonRpcRes.error.message || JSON.stringify(jsonRpcRes.error)}`);
-    }
-
-    if (jsonRpcRes.result && Array.isArray(jsonRpcRes.result.content)) {
-      for (const item of jsonRpcRes.result.content) {
-        if (item.type === 'text' && item.text) {
-          try {
-            return JSON.parse(item.text);
-          } catch {
-            return item.text;
+        if (res.status === 429 || (res.status >= 500 && res.status <= 504)) {
+          if (attempt < maxRetries) {
+            const backoffMs = Math.min(4000, 500 * Math.pow(2, attempt));
+            await new Promise(resolve => setTimeout(resolve, backoffMs));
+            continue;
           }
         }
+
+        if (!res.ok) {
+          throw new Error(`Tana MCP responded with HTTP ${res.status}`);
+        }
+
+        const jsonRpcRes: any = await res.json();
+        if (jsonRpcRes.error) {
+          throw new Error(`Tana MCP error: ${jsonRpcRes.error.message || JSON.stringify(jsonRpcRes.error)}`);
+        }
+
+        if (jsonRpcRes.result && Array.isArray(jsonRpcRes.result.content)) {
+          for (const item of jsonRpcRes.result.content) {
+            if (item.type === 'text' && item.text) {
+              try {
+                return JSON.parse(item.text);
+              } catch {
+                return item.text;
+              }
+            }
+          }
+        }
+
+        return jsonRpcRes.result;
+      } catch (err: any) {
+        if (attempt >= maxRetries) {
+          throw err;
+        }
+        const backoffMs = Math.min(3000, 400 * Math.pow(2, attempt));
+        await new Promise(resolve => setTimeout(resolve, backoffMs));
       }
-    } else if (jsonRpcRes.result) {
-      return jsonRpcRes.result;
     }
     return null;
   }

--- a/worker/src/services/temporal.ts
+++ b/worker/src/services/temporal.ts
@@ -1,0 +1,283 @@
+import { TanaNode, NodeField } from '../types';
+
+const MONTH_NAMES: Record<string, number> = {
+  january: 1, jan: 1,
+  february: 2, feb: 2,
+  march: 3, mar: 3,
+  april: 4, apr: 4,
+  may: 5,
+  june: 6, jun: 6,
+  july: 7, jul: 7,
+  august: 8, aug: 8,
+  september: 9, sep: 9, sept: 9,
+  october: 10, oct: 10,
+  november: 11, nov: 11,
+  december: 12, dec: 12
+};
+
+const DATE_FIELD_NAMES = new Set([
+  'date', 'due date', 'event date', 'when', 'occurrence date',
+  'original date', 'scheduled date', 'start date', 'target date'
+]);
+
+export function parseIsoDate(text?: string): string | null {
+  if (!text) return null;
+  // 1. Matches YYYY-MM-DD
+  const m1 = text.match(/\b(19\d\d|20\d\d)-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])\b/);
+  if (m1) return m1[0];
+
+  // 2. Matches "September 1, 2019" or "Sep 1 2019"
+  const monthsPat = Object.keys(MONTH_NAMES).join('|');
+  const m2 = new RegExp(`\\b(${monthsPat})\\s+(\\d{1,2})(?:st|nd|rd|th)?(?:,)?\\s+(19\\d\\d|20\\d\\d)\\b`, 'i').exec(text);
+  if (m2) {
+    const month = MONTH_NAMES[m2[1].toLowerCase()] || 1;
+    const day = parseInt(m2[2], 10);
+    const yr = parseInt(m2[3], 10);
+    return `${yr.toString().padStart(4, '0')}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
+  }
+
+  // 3. Matches "1 September 2019"
+  const m3 = new RegExp(`\\b(\\d{1,2})(?:st|nd|rd|th)?\\s+(${monthsPat})\\s+(19\\d\\d|20\\d\\d)\\b`, 'i').exec(text);
+  if (m3) {
+    const day = parseInt(m3[1], 10);
+    const month = MONTH_NAMES[m3[2].toLowerCase()] || 1;
+    const yr = parseInt(m3[3], 10);
+    return `${yr.toString().padStart(4, '0')}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
+  }
+
+  return null;
+}
+
+export function parseFieldDate(node: TanaNode): string | null {
+  if (!node.fields) return null;
+  for (const field of node.fields) {
+    const fn = (field.field_name || '').toLowerCase().trim();
+    if (DATE_FIELD_NAMES.has(fn) || fn.includes('date') || fn.includes('when')) {
+      const parsed = parseIsoDate(field.value_text);
+      if (parsed) return parsed;
+    }
+  }
+  return null;
+}
+
+export function isDayNode(node: TanaNode): [boolean, string | null] {
+  const tagNames = (node.supertags || []).map(t => t.tag_name.toLowerCase());
+  const tagIds = (node.supertags || []).map(t => t.tag_id);
+  const hasDayTag = tagNames.includes('day') || tagIds.includes('1Kcq0q_pf5Fn');
+
+  const cleanName = (node.name || '').replace(/<[^>]+>/g, '').trim();
+  const parsedDate = parseIsoDate(cleanName);
+  if (parsedDate) return [true, parsedDate];
+
+  if (hasDayTag) {
+    const fDate = parseFieldDate(node);
+    if (fDate) return [true, fDate];
+    if (node.created_at) {
+      const cDate = parseIsoDate(node.created_at);
+      if (cDate) return [true, cDate];
+    }
+  }
+  return [false, null];
+}
+
+export function resolveNodeProvenance(node: TanaNode, parentChain: TanaNode[]): Record<string, any> {
+  const [selfIsDay, selfDayDate] = isDayNode(node);
+  if (selfIsDay && selfDayDate) {
+    return {
+      effective_date: selfDayDate,
+      date_source: 'day_node',
+      date_source_node_id: node.id,
+      calendar_distance: 0,
+      calendar_path: selfDayDate,
+      ancestor_day_node_id: node.id,
+      ancestor_year_node_id: selfDayDate.substring(0, 4)
+    };
+  }
+
+  let ancestorDayId: string | null = null;
+  let ancestorDayDate: string | null = null;
+  let calendarDistance: number | null = null;
+
+  for (let i = 0; i < parentChain.length; i++) {
+    const p = parentChain[i];
+    const [pIsDay, pDate] = isDayNode(p);
+    if (pIsDay && pDate && !ancestorDayId) {
+      ancestorDayId = p.id;
+      ancestorDayDate = pDate;
+      calendarDistance = i + 1;
+    }
+  }
+
+  const explicitFieldDate = parseFieldDate(node);
+
+  if (ancestorDayDate) {
+    return {
+      effective_date: ancestorDayDate,
+      date_source: 'day_node',
+      date_source_node_id: ancestorDayId,
+      calendar_distance: calendarDistance,
+      calendar_path: ancestorDayDate,
+      ancestor_day_node_id: ancestorDayId,
+      ancestor_year_node_id: ancestorDayDate.substring(0, 4)
+    };
+  }
+
+  if (explicitFieldDate) {
+    return {
+      effective_date: explicitFieldDate,
+      date_source: 'field',
+      date_source_node_id: node.id,
+      calendar_distance: 0,
+      calendar_path: explicitFieldDate,
+      ancestor_day_node_id: null,
+      ancestor_year_node_id: explicitFieldDate.substring(0, 4)
+    };
+  }
+
+  if (node.created_at) {
+    const cDate = parseIsoDate(node.created_at);
+    if (cDate) {
+      return {
+        effective_date: cDate,
+        date_source: 'fallback_created',
+        date_source_node_id: node.id,
+        calendar_distance: null,
+        calendar_path: cDate,
+        ancestor_day_node_id: null,
+        ancestor_year_node_id: cDate.substring(0, 4)
+      };
+    }
+  }
+
+  return {
+    effective_date: null,
+    date_source: 'none',
+    date_source_node_id: null,
+    calendar_distance: null,
+    calendar_path: null,
+    ancestor_day_node_id: null,
+    ancestor_year_node_id: null
+  };
+}
+
+export function computeTemporalScore(
+  nodeDateStr?: string,
+  targetDateStr?: string,
+  dateFromStr?: string,
+  dateToStr?: string
+): number {
+  if (!nodeDateStr) return 0.0;
+
+  const nTime = new Date(nodeDateStr.substring(0, 10)).getTime();
+  if (isNaN(nTime)) return 0.0;
+
+  if (dateFromStr) {
+    const fTime = new Date(dateFromStr.substring(0, 10)).getTime();
+    if (!isNaN(fTime) && nTime < fTime) return 0.0;
+  }
+  if (dateToStr) {
+    const tTime = new Date(dateToStr.substring(0, 10)).getTime();
+    if (!isNaN(tTime) && nTime > tTime) return 0.0;
+  }
+
+  if (!targetDateStr) return 1.0;
+
+  const targetTime = new Date(targetDateStr.substring(0, 10)).getTime();
+  if (isNaN(targetTime)) return 0.5;
+
+  const deltaDays = Math.abs(Math.round((nTime - targetTime) / (1000 * 60 * 60 * 24)));
+
+  if (deltaDays === 0) return 1.0;
+  if (deltaDays === 1) return 0.95;
+  if (deltaDays <= 3) return 0.85;
+  if (deltaDays <= 7) return 0.70;
+  if (deltaDays <= 14) return 0.50;
+  if (deltaDays <= 30) return 0.25;
+  return Math.max(0.0, 0.25 * Math.exp(-(deltaDays - 30) / 60.0));
+}
+
+export function classifyTemporalRelationship(
+  node: TanaNode,
+  targetDateStr?: string,
+  targetYear?: string
+): string {
+  const fieldDate = parseFieldDate(node);
+  if (fieldDate && node.effective_date && node.date_source === 'day_node') {
+    if (fieldDate.substring(0, 4) !== node.effective_date.substring(0, 4)) {
+      return 'conflicting';
+    }
+  }
+
+  const fullText = `${node.name} ${node.description || ''}`.toLowerCase();
+  const textYears: string[] = fullText.match(/\b(19\d\d|20\d\d)\b/g) || [];
+  const refYear = targetYear || (targetDateStr ? targetDateStr.substring(0, 4) : null);
+
+  if (node.effective_date && refYear) {
+    const nodeYear = node.effective_date.substring(0, 4);
+    if (nodeYear !== refYear && textYears.includes(refYear)) {
+      return 'retrospective';
+    }
+    if (nodeYear === refYear) {
+      return 'contemporaneous';
+    }
+  }
+
+  if (!node.effective_date || node.date_source === 'none') {
+    return 'undated';
+  }
+
+  return 'contemporaneous';
+}
+
+export function parseTemporalIntent(queryText: string, referenceDate?: Date): Record<string, any> {
+  const ref = referenceDate || new Date();
+  const q = queryText.trim().toLowerCase();
+
+  const patterns = [
+    /this time in (\d{4})/,
+    /around (?:the\s+)?(\d{1,2}(?:st|nd|rd|th)?\s+)?([a-z]+)\s+(\d{4})/,
+    /in ([a-z]+)\s+(\d{4})/,
+    /during (\d{4})/,
+    /back in (\d{4})/,
+    /in (\d{4})/,
+    /last year/,
+    /(\d+)\s+years ago/,
+    /around this date last year/,
+    /what was i doing/,
+    /what was happening/
+  ];
+
+  let hasIntent = false;
+  for (const pat of patterns) {
+    if (pat.test(q)) {
+      hasIntent = true;
+      break;
+    }
+  }
+
+  let targetDate: string | null = null;
+  let dateFrom: string | null = null;
+  let dateTo: string | null = null;
+  let temporalMode = 'none';
+
+  if (hasIntent) {
+    temporalMode = 'strict';
+    const mThisTime = q.match(/(?:around\s+)?this time (?:in|of)\s+(\d{4})/);
+    if (mThisTime) {
+      const yr = parseInt(mThisTime[1], 10);
+      const mm = (ref.getMonth() + 1).toString().padStart(2, '0');
+      const dd = ref.getDate().toString().padStart(2, '0');
+      targetDate = `${yr}-${mm}-${dd}`;
+      dateFrom = `${yr}-${mm}-01`;
+      dateTo = `${yr}-${mm}-28`;
+    }
+  }
+
+  return {
+    has_temporal_intent: hasIntent,
+    target_date: targetDate,
+    date_from: dateFrom,
+    date_to: dateTo,
+    temporal_mode: temporalMode
+  };
+}

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -38,6 +38,15 @@ export interface TanaNode {
   backlinks: string[];
   breadcrumbs: string[];
   deep_link?: string;
+  effective_date?: string;
+  date_source?: string;
+  date_source_node_id?: string;
+  calendar_distance?: number;
+  calendar_path?: string;
+  ancestor_day_node_id?: string;
+  ancestor_week_node_id?: string;
+  ancestor_month_node_id?: string;
+  ancestor_year_node_id?: string;
 }
 
 export interface ContextAcquisitionRequest {
@@ -46,6 +55,10 @@ export interface ContextAcquisitionRequest {
   scope?: string;
   max_nodes?: number;
   include_children?: boolean;
+  target_date?: string;
+  date_from?: string;
+  date_to?: string;
+  temporal_mode?: 'none' | 'boost' | 'filter' | 'strict';
 }
 
 export interface ContextNode {
@@ -61,6 +74,9 @@ export interface ContextNode {
   inclusion_reason: string;
   relevance_score: number;
   deep_link: string;
+  effective_date?: string;
+  date_source?: string;
+  temporal_relationship?: string;
 }
 
 export interface ContextPacket {
@@ -73,10 +89,56 @@ export interface ContextPacket {
   graph_expansion_count: number;
   latency_ms: number;
   timestamp: string;
+  target_date?: string;
+  temporal_mode?: string;
+  insufficient_evidence?: boolean;
 }
 
 export interface ScoredCandidate {
   node: TanaNode;
   score: number;
   reason: string;
+}
+
+export interface SemanticSearchRequest {
+  query: string;
+  limit?: number;
+  tag_filter?: string;
+  target_date?: string;
+  date_from?: string;
+  date_to?: string;
+  temporal_mode?: 'none' | 'boost' | 'filter' | 'strict';
+  temporal_weight?: number;
+}
+
+export interface SearchResultItem {
+  id: string;
+  name: string;
+  description: string;
+  score: number;
+  semantic_score?: number;
+  lexical_score?: number;
+  breadcrumbs: string[];
+  tags: string[];
+  parent_id?: string;
+  last_updated?: string;
+  effective_date?: string;
+  date_source?: string;
+  date_source_node_id?: string;
+  calendar_path?: string;
+  ancestor_day_node_id?: string;
+  ancestor_month_node_id?: string;
+  ancestor_year_node_id?: string;
+  temporal_relationship?: string;
+  temporal_score?: number;
+}
+
+export interface SearchResponse {
+  query: string;
+  total_hits: number;
+  results: SearchResultItem[];
+  latency_ms: number;
+  target_date?: string;
+  temporal_mode?: string;
+  insufficient_evidence?: boolean;
 }


### PR DESCRIPTION
Closes #24.

### Implementation Summary
- **Calendar Lineage & Provenance**: Added , , , , , , , ,  to , SQLite schema, and Cloudflare D1.
- **Precedence Engine**: Day/calendar ancestor > explicit date field > explicit calendar rel > created_at fallback.
- **Search Engine & Gating**: Implemented , , and  modes in .
- **Temporal Proximity Scoring & Classification**: Piecewise decay scoring and relationship classification (, , , ).
- **Calendar-First Candidate Windowing**: Initial ±7-day candidate collection with progressive widening (±14d, ±30d, ±60d) and sparse history signalling.
- **Edge Worker & MCP Parity**: Deployed live to Cloudflare Workers with D1 schema migrations.
- **Test Suite**: 28 passed unit/regression tests.